### PR TITLE
doc: fix the code snippet of returning Error in fn handle()

### DIFF
--- a/docs/book/src/test_add_more.md
+++ b/docs/book/src/test_add_more.md
@@ -68,7 +68,7 @@ Now we update our command logic to return an error when this situation arises:
             BankAccountCommand::WithdrawMoney { amount } => {
                 let balance = self.balance - amount;
                 if balance < 0_f64 {
-                    return Err(AggregateError::new("funds not available"));
+                    return Err(BankAccountError(String::from("funds not available")));
                 }
                 Ok(vec![BankAccountEvent::CustomerWithdrewCash {
                     amount,

--- a/docs/book/src/test_add_more.md
+++ b/docs/book/src/test_add_more.md
@@ -68,7 +68,7 @@ Now we update our command logic to return an error when this situation arises:
             BankAccountCommand::WithdrawMoney { amount } => {
                 let balance = self.balance - amount;
                 if balance < 0_f64 {
-                    return Err(BankAccountError(String::from("funds not available")));
+                    return Err(BankAccountError::from("funds not available"));
                 }
                 Ok(vec![BankAccountEvent::CustomerWithdrewCash {
                     amount,


### PR DESCRIPTION
Hello,

I was following the [documentation](https://doc.rust-cqrs.org/intro.html), and encountered an error within the code snippet of returning the error in section [3.1. Adding more complex logic](https://doc.rust-cqrs.org/test_add_more.html#verify-funds-are-available).

When I was running `cargo build` with the current code snippet, I had:

```
error[E0599]: no variant or associated item named `new` found for enum `AggregateError` in the current scope
   --> src/main.rs:123:48
    |
123 |                     return Err(AggregateError::new("funds not available"));
    |                                                ^^^ variant or associated item not found in `AggregateError<_>`

For more information about this error, try `rustc --explain E0599`.
warning: `mybank` (bin "mybank") generated 1 warning
error: could not compile `mybank` due to previous error; 1 warning emitted
```

With this fix, the test can be run without error.

Thank you very much for your work! It is amazing :smile: 

More info:

```sh
$ cargo --version
cargo 1.62.1 (a748cf5a3 2022-06-08)
$ rustc --verbose --version
rustc 1.62.1 (e092d0b6b 2022-07-16)
binary: rustc
commit-hash: e092d0b6b43f2de967af0887873151bb1c0b18d3
commit-date: 2022-07-16
host: x86_64-unknown-linux-gnu
release: 1.62.1
LLVM version: 14.0.5
```