### PR TITLE
configure the MSRV

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ documentation = "https://docs.rs/cqrs-es"
 repository = "https://github.com/serverlesstechnology/cqrs"
 readme = "README.md"
 exclude = ["docs"]
+rust-version = "1.56.1"
 
 [dependencies]
 async-trait = "0.1"


### PR DESCRIPTION
configure the MSRV in Cargo.toml

note that the MSRV was determined using ((cargo-msrv)[https://github.com/foresterre/cargo-msrv])-

```
cargo msrv --bisect
```