### PR TITLE
add continuous integration workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,46 @@
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+name: Continuous integration
+
+jobs:
+  test:
+    name: test
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        build: [msrv, stable, nightly, macos, windows]
+        include:
+          - build: msrv
+            os: ubuntu-latest
+            rust: 1.56.1
+          - build: stable
+            os: ubuntu-latest
+            rust: stable
+          - build: nightly
+            os: ubuntu-latest
+            rust: nightly
+          - build: macos
+            os: macos-latest
+            rust: stable
+          - build: windows
+            os: windows-latest
+            rust: stable
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.rust }}
+      - run: cargo test
+
+  fmt:
+    name: format
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: rustfmt
+      - run: cargo fmt -- --check


### PR DESCRIPTION
adds github continuous integration workflows to check formatting and tests

note that this PR is a prerequisite for merging #36 (since this PR prevents dependabot from inadvertently bumping the minimum compiler version for downstream users). #36 is very high-value for this crate since it is security conscious. Dependabot will automatically open PRs to address security vulnerabilities (as well as plain old outdated dependencies)

you can see the results of these checks here - https://github.com/danieleades/cqrs/pull/1