### PR TITLE
move private 'docs' modules to an example crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,12 @@ readme = "README.md"
 exclude = ["docs"]
 rust-version = "1.56.1"
 
+[workspace]
+members = [
+    ".",
+    "example",
+]
+
 [dependencies]
 async-trait = "0.1"
 serde = { version = "1.0", features = ["derive"]}

--- a/example/Cargo.toml
+++ b/example/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "example"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+async-trait = "0.1.60"
+cqrs-es = { version = "0.4.5", path = ".." }
+serde = { version = "1.0.152", features = ["derive"] }
+serde_json = "1.0.91"

--- a/example/src/aggregate.rs
+++ b/example/src/aggregate.rs
@@ -3,10 +3,10 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::fmt::{Display, Formatter};
 
-use crate::persist::{
+use cqrs_es::persist::{
     PersistedEventRepository, PersistenceError, ReplayStream, SerializedEvent, SerializedSnapshot,
 };
-use crate::{Aggregate, DomainEvent, EventEnvelope, Query};
+use cqrs_es::{Aggregate, DomainEvent, EventEnvelope, Query};
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
 pub enum MyEvents {
@@ -178,7 +178,7 @@ pub enum CustomerCommand {
 
 #[cfg(test)]
 mod doc_tests {
-    use crate::test::TestFramework;
+    use cqrs_es::test::TestFramework;
 
     use super::*;
 

--- a/example/src/lib.rs
+++ b/example/src/lib.rs
@@ -1,0 +1,4 @@
+mod aggregate;
+mod persist;
+
+use aggregate::MyAggregate;

--- a/example/src/persist.rs
+++ b/example/src/persist.rs
@@ -1,11 +1,11 @@
-use crate::doc::MyAggregate;
-use crate::persist::event_stream::ReplayStream;
-use crate::persist::{
+use crate::MyAggregate;
+use async_trait::async_trait;
+use cqrs_es::persist::event_stream::ReplayStream;
+use cqrs_es::persist::{
     PersistedEventRepository, PersistenceError, SerializedEvent, SerializedSnapshot, ViewContext,
     ViewRepository,
 };
-use crate::{Aggregate, EventEnvelope, View};
-use async_trait::async_trait;
+use cqrs_es::{Aggregate, EventEnvelope, View};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 


### PR DESCRIPTION
moves the private 'docs' modules into a separate crate.

This doesn't currently build, as the docs rely on a private type, not exposed in the public API (`cqrs_es::persist::event_stream::ReplayStream`).