### PR TITLE
Add async test method

### DIFF
--- a/src/doc.rs
+++ b/src/doc.rs
@@ -14,10 +14,7 @@ pub enum MyEvents {
 }
 impl DomainEvent for MyEvents {
     fn event_type(&self) -> String {
-        match self {
-            Self::SomethingWasDone => "SomethingWasDone".to_string(),
-            Self::SomethingElseWasDone => "SomethingElseWasDone".to_string(),
-        }
+        format!("{:?}", &self)
     }
     fn event_version(&self) -> String {
         "0.1.0".to_string()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,25 +40,5 @@ pub mod doc;
 pub mod mem_store;
 
 pub mod persist;
-/// This module provides a test framework for building a resilient test base around aggregates.
-/// A `TestFramework` should be used to build a comprehensive set of aggregate tests to verify
-/// your application logic.
-///
-/// ```rust
-/// # use cqrs_es::test::TestFramework;
-/// # use cqrs_es::doc::{Customer, CustomerEvent, CustomerCommand, CustomerService};
-/// # fn test() {
-/// type CustomerTestFramework = TestFramework<Customer>;
-///
-/// CustomerTestFramework::with(CustomerService::default())
-///     .given_no_previous_events()
-///     .when(CustomerCommand::AddCustomerName{
-///             name: "John Doe".to_string()
-///         })
-///     .then_expect_events(vec![
-///         CustomerEvent::NameAdded{
-///             name: "John Doe".to_string()
-///         }]);
-/// # }
-/// ```
+
 pub mod test;

--- a/src/test/executor.rs
+++ b/src/test/executor.rs
@@ -1,0 +1,93 @@
+use crate::aggregate::Aggregate;
+use crate::test::AggregateResultValidator;
+
+/// Holds the initial event state of an aggregate and accepts a command.
+pub struct AggregateTestExecutor<A>
+where
+    A: Aggregate,
+{
+    events: Vec<A::Event>,
+    service: A::Services,
+}
+
+impl<A> AggregateTestExecutor<A>
+where
+    A: Aggregate,
+{
+    /// Consumes a command and provides a validator object to test against.
+    ///
+    /// ```
+    /// # use cqrs_es::doc::{MyAggregate, MyCommands, MyService};
+    /// use cqrs_es::test::TestFramework;
+    ///
+    /// let executor = TestFramework::<MyAggregate>::with(MyService)
+    ///     .given_no_previous_events();
+    ///
+    /// let validator = executor.when(MyCommands::DoSomething);
+    /// ```
+    ///
+    /// For `async` tests use `when_async` instead.
+    pub fn when(self, command: A::Command) -> AggregateResultValidator<A> {
+        let result = when::<A>(self.events, command, self.service);
+        AggregateResultValidator::new(result)
+    }
+
+    /// Consumes a command in an `async` test and provides a validator object
+    /// to test against.
+    ///
+    /// ```
+    /// # use cqrs_es::doc::{MyAggregate, MyCommands, MyService};
+    /// use cqrs_es::test::TestFramework;
+    ///
+    /// #[tokio::test]
+    /// async fn test() {
+    ///     let executor = TestFramework::<MyAggregate>::with(MyService)
+    ///         .given_no_previous_events();
+    ///
+    ///     let validator = executor.when_async(MyCommands::DoSomething).await;
+    /// }
+    /// ```
+    pub async fn when_async(self, command: A::Command) -> AggregateResultValidator<A> {
+        let mut aggregate = A::default();
+        for event in self.events {
+            aggregate.apply(event);
+        }
+        let result = aggregate.handle(command, &self.service).await;
+        AggregateResultValidator::new(result)
+    }
+
+    /// Adds additional events to an aggregate test.
+    ///
+    /// ```
+    /// # use cqrs_es::doc::{MyAggregate, MyEvents, MyService};
+    /// use cqrs_es::test::TestFramework;
+    ///
+    /// let executor = TestFramework::<MyAggregate>::with(MyService)
+    ///     .given(vec![MyEvents::SomethingWasDone])
+    ///     .and(vec![MyEvents::SomethingElseWasDone]);
+    /// ```
+    #[must_use]
+    pub fn and(self, new_events: Vec<A::Event>) -> Self {
+        let mut events = self.events;
+        events.extend(new_events);
+        let service = self.service;
+        AggregateTestExecutor { events, service }
+    }
+
+    pub(crate) fn new(events: Vec<A::Event>, service: A::Services) -> Self {
+        Self { events, service }
+    }
+}
+
+#[tokio::main(flavor = "current_thread")]
+async fn when<A: Aggregate>(
+    events: Vec<A::Event>,
+    command: A::Command,
+    service: A::Services,
+) -> Result<Vec<A::Event>, A::Error> {
+    let mut aggregate = A::default();
+    for event in events {
+        aggregate.apply(event);
+    }
+    aggregate.handle(command, &service).await
+}

--- a/src/test/framework.rs
+++ b/src/test/framework.rs
@@ -1,0 +1,47 @@
+use crate::aggregate::Aggregate;
+use crate::test::AggregateTestExecutor;
+
+/// A framework for rigorously testing the aggregate logic, one of the *most important*
+/// parts of any DDD system.
+pub struct TestFramework<A: Aggregate> {
+    service: A::Services,
+}
+
+impl<A: Aggregate> TestFramework<A> {
+    /// Create a test framework using the provided service.
+    pub fn with(service: A::Services) -> Self {
+        Self { service }
+    }
+}
+
+impl<A> TestFramework<A>
+where
+    A: Aggregate,
+{
+    /// Initiates an aggregate test with no previous events.
+    ///
+    /// ```
+    /// # use cqrs_es::doc::{MyAggregate, MyService};
+    /// use cqrs_es::test::TestFramework;
+    ///
+    /// let executor = TestFramework::<MyAggregate>::with(MyService)
+    ///     .given_no_previous_events();
+    /// ```
+    #[must_use]
+    pub fn given_no_previous_events(self) -> AggregateTestExecutor<A> {
+        AggregateTestExecutor::new(Vec::new(), self.service)
+    }
+    /// Initiates an aggregate test with a collection of previous events.
+    ///
+    /// ```
+    /// # use cqrs_es::doc::{MyAggregate, MyEvents, MyService};
+    /// use cqrs_es::test::TestFramework;
+    ///
+    /// let executor = TestFramework::<MyAggregate>::with(MyService)
+    ///     .given(vec![MyEvents::SomethingWasDone]);
+    /// ```
+    #[must_use]
+    pub fn given(self, events: Vec<A::Event>) -> AggregateTestExecutor<A> {
+        AggregateTestExecutor::new(events, self.service)
+    }
+}

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -1,0 +1,28 @@
+//! This module provides a test framework for building a resilient test base around aggregates.
+//! A `TestFramework` should be used to build a comprehensive set of aggregate tests to verify
+//! your application logic.
+//!
+//! ```rust
+//! # use cqrs_es::test::TestFramework;
+//! # use cqrs_es::doc::{Customer, CustomerEvent, CustomerCommand, CustomerService};
+//! # fn test() {
+//! type CustomerTestFramework = TestFramework<Customer>;
+//!
+//! CustomerTestFramework::with(CustomerService::default())
+//!     .given_no_previous_events()
+//!     .when(CustomerCommand::AddCustomerName{
+//!             name: "John Doe".to_string()
+//!         })
+//!     .then_expect_events(vec![
+//!         CustomerEvent::NameAdded{
+//!             name: "John Doe".to_string()
+//!         }]);
+//! # }
+//! ```
+mod executor;
+mod framework;
+mod validator;
+
+pub use crate::test::executor::*;
+pub use crate::test::framework::*;
+pub use crate::test::validator::*;

--- a/src/test/validator.rs
+++ b/src/test/validator.rs
@@ -1,119 +1,5 @@
 use crate::aggregate::Aggregate;
 
-/// A framework for rigorously testing the aggregate logic, one of the ***most important***
-/// parts of any DDD system.
-///
-pub struct TestFramework<A: Aggregate> {
-    service: A::Services,
-}
-
-impl<A: Aggregate> TestFramework<A> {
-    /// Create a test framework using the provided service.
-    pub fn with(service: A::Services) -> Self {
-        Self { service }
-    }
-}
-
-impl<A> TestFramework<A>
-where
-    A: Aggregate,
-{
-    /// Initiates an aggregate test with no previous events.
-    ///
-    /// ```
-    /// # use cqrs_es::doc::{MyAggregate, MyService};
-    /// use cqrs_es::test::TestFramework;
-    ///
-    /// let executor = TestFramework::<MyAggregate>::with(MyService)
-    ///     .given_no_previous_events();
-    /// ```
-    #[must_use]
-    pub fn given_no_previous_events(self) -> AggregateTestExecutor<A> {
-        AggregateTestExecutor {
-            events: Vec::new(),
-            service: self.service,
-        }
-    }
-    /// Initiates an aggregate test with a collection of previous events.
-    ///
-    /// ```
-    /// # use cqrs_es::doc::{MyAggregate, MyEvents, MyService};
-    /// use cqrs_es::test::TestFramework;
-    ///
-    /// let executor = TestFramework::<MyAggregate>::with(MyService)
-    ///     .given(vec![MyEvents::SomethingWasDone]);
-    /// ```
-    #[must_use]
-    pub fn given(self, events: Vec<A::Event>) -> AggregateTestExecutor<A> {
-        AggregateTestExecutor {
-            events,
-            service: self.service,
-        }
-    }
-}
-
-/// Holds the initial event state of an aggregate and accepts a command.
-pub struct AggregateTestExecutor<A>
-where
-    A: Aggregate,
-{
-    events: Vec<A::Event>,
-    service: A::Services,
-}
-
-impl<A> AggregateTestExecutor<A>
-where
-    A: Aggregate,
-{
-    /// Consumes a command and using the state details previously passed provides a validator object
-    /// to test against.
-    ///
-    /// ```
-    /// # use cqrs_es::doc::{MyAggregate, MyCommands, MyService};
-    /// use cqrs_es::test::TestFramework;
-    ///
-    /// let executor = TestFramework::<MyAggregate>::with(MyService)
-    ///     .given_no_previous_events();
-    ///
-    /// let validator = executor.when(MyCommands::DoSomething);
-    /// ```
-    pub fn when(self, command: A::Command) -> AggregateResultValidator<A> {
-        let result = when::<A>(self.events, command, self.service);
-        AggregateResultValidator { result }
-    }
-
-    /// Adds additional events to an aggregate test.
-    ///
-    /// ```
-    /// # use cqrs_es::doc::{MyAggregate, MyEvents, MyService};
-    /// use cqrs_es::test::TestFramework;
-    ///
-    /// let executor = TestFramework::<MyAggregate>::with(MyService)
-    ///     .given(vec![MyEvents::SomethingWasDone])
-    ///     .and(vec![MyEvents::SomethingElseWasDone]);
-    /// ```
-    #[must_use]
-    pub fn and(self, new_events: Vec<A::Event>) -> Self {
-        let mut events = self.events;
-        events.extend(new_events);
-        let service = self.service;
-        AggregateTestExecutor { events, service }
-    }
-}
-
-#[tokio::main(flavor = "current_thread")]
-async fn when<A: Aggregate>(
-    events: Vec<A::Event>,
-    command: A::Command,
-    service: A::Services,
-) -> Result<Vec<A::Event>, A::Error> {
-    let mut aggregate = A::default();
-    for event in events {
-        aggregate.apply(event);
-    }
-    aggregate.handle(command, &service).await
-}
-
 /// Validation object for the `TestFramework` package.
 pub struct AggregateResultValidator<A>
 where
@@ -184,6 +70,10 @@ impl<A: Aggregate> AggregateResultValidator<A> {
     /// ```
     pub fn inspect_result(self) -> Result<Vec<A::Event>, A::Error> {
         self.result
+    }
+
+    pub(crate) fn new(result: Result<Vec<A::Event>, A::Error>) -> Self {
+        Self { result }
     }
 }
 impl<A> AggregateResultValidator<A>


### PR DESCRIPTION
The current test framework can not be run under an async test. This adds an alternate method for processing a command that can be used instead.