### PR TITLE
Upcasting replays

### DIFF
--- a/src/persist/event_stream.rs
+++ b/src/persist/event_stream.rs
@@ -1,6 +1,7 @@
-use crate::persist::{PersistenceError, SerializedEvent};
+use crate::persist::{PersistenceError, SerializedEvent, EventUpcaster};
 use crate::{Aggregate, EventEnvelope};
 use tokio::sync::mpsc::{Receiver, Sender};
+
 
 /// Accesses a domain event stream for a particular aggregate.
 ///
@@ -16,14 +17,38 @@ impl ReplayStream {
         (ReplayFeed { sender }, Self { queue })
     }
 
-    /// Receive the next event or error in the stream, if no event is available this will block.
+    /// Receive the next upcasted event or error in the stream, if no event is available this will block.
     pub async fn next<A: Aggregate>(
         &mut self,
+        event_upcasters: &Option<Vec<Box<dyn EventUpcaster>>>,
     ) -> Option<Result<EventEnvelope<A>, PersistenceError>> {
         self.queue
             .recv()
             .await
-            .map(|result| result.and_then(TryInto::try_into))
+            .map(|result| {
+                result
+                    .and_then(|serialized_event| upcast_event(serialized_event, event_upcasters).try_into())
+            })
+    }
+}
+
+fn upcast_event(
+    event: SerializedEvent,
+    upcasters: &Option<Vec<Box<dyn EventUpcaster>>>,
+) -> SerializedEvent {
+    match upcasters {
+        None => event,
+        Some(upcasters) => {
+            let mut upcasted_event = event;
+            for upcaster in upcasters {
+                if upcaster
+                    .can_upcast(&upcasted_event.event_type, &upcasted_event.event_version)
+                {
+                    upcasted_event = upcaster.upcast(upcasted_event);
+                }
+            }
+            upcasted_event
+        }
     }
 }
 
@@ -54,7 +79,7 @@ mod test {
             .await
             .unwrap();
         drop(feed);
-        let found = stream.next::<MyAggregate>().await;
+        let found = stream.next::<MyAggregate>(&None).await;
         assert!(
             matches!(
                 found.unwrap().unwrap_err(),

--- a/src/persist/replay.rs
+++ b/src/persist/replay.rs
@@ -1,7 +1,7 @@
 use std::marker::PhantomData;
 
-use crate::persist::{PersistedEventRepository, PersistenceError, QueryErrorHandler};
 use crate::{Aggregate, AggregateError, EventEnvelope, Query};
+use crate::persist::{EventUpcaster, PersistedEventRepository, PersistenceError, QueryErrorHandler};
 
 /// A utility for replaying committed events to a `Query`.
 ///
@@ -15,22 +15,23 @@ use crate::{Aggregate, AggregateError, EventEnvelope, Query};
 /// }
 /// ```
 pub struct QueryReplay<R, Q, A>
-where
-    R: PersistedEventRepository,
-    Q: Query<A>,
-    A: Aggregate,
+    where
+        R: PersistedEventRepository,
+        Q: Query<A>,
+        A: Aggregate,
 {
     repository: R,
     query: Q,
+    event_upcasters: Option<Vec<Box<dyn EventUpcaster>>>,
     error_handler: Option<Box<QueryErrorHandler>>,
     phantom_data: PhantomData<A>,
 }
 
 impl<R, Q, A> QueryReplay<R, Q, A>
-where
-    R: PersistedEventRepository,
-    Q: Query<A>,
-    A: Aggregate,
+    where
+        R: PersistedEventRepository,
+        Q: Query<A>,
+        A: Aggregate
 {
     /// Create a new replay utility using the provided event repository as the source and the
     /// query as the target.
@@ -38,10 +39,27 @@ where
         Self {
             repository,
             query,
+            event_upcasters: None,
             error_handler: None,
             phantom_data: PhantomData::default(),
         }
     }
+
+    /// Configures the query replayer to use event upcasters when replaying.
+    /// The EventUpcasters within the Vec should be placed in the
+    /// order that they should be applied
+    ///
+    /// E.g., an upcaster for version 0.2.3 should be placed before an upcaster for version 0.2.4
+    pub fn with_upcasters(self, event_upcasters: Vec<Box<dyn EventUpcaster>>) -> Self {
+        Self {
+            repository: self.repository,
+            query: self.query,
+            error_handler: self.error_handler,
+            event_upcasters: Some(event_upcasters),
+            phantom_data: self.phantom_data,
+        }
+    }
+
 
     /// Allows the user to apply a custom error handler to the query replay.
     ///
@@ -60,7 +78,7 @@ where
     /// Replay the events of a single aggregate instance.
     pub async fn replay(&self, aggregate_id: &str) -> Result<(), AggregateError<A::Error>> {
         let mut stream = self.repository.stream_events::<A>(aggregate_id).await?;
-        while let Some(event) = stream.next().await {
+        while let Some(event) = stream.next(&self.event_upcasters).await {
             self.apply(event).await;
         }
         Ok(())
@@ -69,7 +87,7 @@ where
     /// Replay the events of all aggregate instances within the database.
     pub async fn replay_all(&self) -> Result<(), AggregateError<A::Error>> {
         let mut stream = self.repository.stream_all_events::<A>().await?;
-        while let Some(event) = stream.next().await {
+        while let Some(event) = stream.next(&self.event_upcasters).await {
             self.apply(event).await;
         }
         Ok(())
@@ -96,12 +114,14 @@ mod test {
     use std::sync::{Arc, Mutex};
 
     use async_trait::async_trait;
+    use serde_json::{json, Value};
+    use serde_json::Value::Object;
 
+    use crate::{EventEnvelope, Query};
     use crate::doc::{MyAggregate, MyEvents};
     use crate::persist::event_store::shared_test::MockRepo;
     use crate::persist::replay::QueryReplay;
-    use crate::persist::SerializedEvent;
-    use crate::{EventEnvelope, Query};
+    use crate::persist::{SemanticVersionEventUpcaster, SerializedEvent};
 
     #[derive(Debug)]
     struct MockQuery {
@@ -158,6 +178,65 @@ mod test {
 
         let events = event_list.lock().unwrap().to_owned();
         assert_events_eq(&events, &expected_events);
+    }
+
+    #[tokio::test]
+    async fn query_replay_with_upcasting() {
+        let expected_events = vec![EventEnvelope {
+            aggregate_id: AGGREGATE_ID.to_string(),
+            sequence: 1,
+            payload: MyEvents::SomethingWasDone,
+            metadata: HashMap::default(),
+        }];
+
+
+        // a "legacy" event that contains a single property
+        // that the upcasting function should remove to upcast
+        // to the expected event
+        let ser_events: Vec<SerializedEvent> = vec![SerializedEvent {
+            aggregate_id: AGGREGATE_ID.to_string(),
+            sequence: 1,
+            aggregate_type: "MyAggregate".to_string(),
+            event_type: "SomethingWasDone".to_string(),
+            event_version: "0.0.1".to_string(),
+            payload: json!({"LegacyName": ()}),
+            metadata: Object(Default::default()),
+        }];
+
+        fn upcasting_fn(_payload: Value) -> Value {
+            // We return an implemented event, which indicates
+            // that an "upcast" has happened
+            json!({"SomethingWasDone": ()})
+        }
+
+        let event_repo = MockRepo::with_events(Ok(ser_events.clone()));
+        let (query, event_list) = MockQuery::new();
+        let query_replay = QueryReplay::new(event_repo, query)
+            .with_upcasters(vec![Box::new(SemanticVersionEventUpcaster::new(
+                "SomethingWasDone",
+                "0.1.0",
+                Box::new(upcasting_fn),
+            ))])
+            ;
+
+        query_replay.replay(AGGREGATE_ID).await.unwrap();
+
+        let events = event_list.lock().unwrap().to_owned();
+        assert_events_eq(&expected_events, &events);
+
+        // query all
+        let event_repo = MockRepo::with_events(Ok(ser_events));
+        let (query, event_list) = MockQuery::new();
+        let query_replay = QueryReplay::new(event_repo, query)
+            .with_upcasters(vec![Box::new(SemanticVersionEventUpcaster::new(
+                "SomethingWasDone",
+                "0.1.0",
+                Box::new(upcasting_fn),
+            ))]);
+        query_replay.replay_all().await.unwrap();
+
+        let events = event_list.lock().unwrap().to_owned();
+        assert_events_eq(&expected_events, &events);
     }
 
     fn assert_events_eq(


### PR DESCRIPTION
An attempt at implementing upcasting in query replays. I think this implementation has the least amount of breaking changes without, it requires that `ReplayStream` accepts upcasters in its `next(...)` function. Another approach could be to have a method like `next_with_upcasting(...)`. If that is preferred, I can change it. Other solutions like passing them to `stream_all_events(...)` would require updating other crates and possibly breaking people's own implementations of event repositories.

Let me know if I missed something :)