### PR TITLE
Update MSRV to 1.70.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
         include:
           - build: msrv
             os: ubuntu-latest
-            rust: 1.63.0
+            rust: 1.70.0
           - build: stable
             os: ubuntu-latest
             rust: stable

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,11 +10,11 @@ documentation = "https://docs.rs/cqrs-es"
 repository = "https://github.com/serverlesstechnology/cqrs"
 readme = "README.md"
 exclude = ["docs"]
-rust-version = "1.71.0"
+rust-version = "1.70.0"
 
 [dependencies]
 async-trait = "0.1"
-serde = { version = "1.0", features = ["derive"]}
+serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "^1.0.37"
 tokio = { version = "1", features = ["macros", "sync", "rt"] }


### PR DESCRIPTION
Because `tokio-macros v2.4.0` requires rustc 1.70 or newer so cqrs needs to update the MSRV to 1.70.0.

  error: package `tokio-macros v2.4.0` cannot be built because it requires rustc 1.70
  or newer, while the currently active rustc version is 1.63.0

See https://github.com/serverlesstechnology/cqrs/actions/runs/10852588958/job/30118970357