### PR TITLE
remove some uses of 'async-trait'

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ documentation = "https://docs.rs/cqrs-es"
 repository.workspace = true
 readme = "README.md"
 exclude = ["docs"]
-rust-version = "1.70.0"
+rust-version = "1.79.0"
 
 [dependencies]
 async-trait = "0.1"

--- a/docs/book/src/intro_add_aggregate.md
+++ b/docs/book/src/intro_add_aggregate.md
@@ -19,7 +19,6 @@ In order to operate within the `cqrs-es` framework, we will need the traits, `De
 (all usually derived) and we will implement `cqrs_es::Aggregate`, minus any of the business logic. 
 
 ```rust
-#[async_trait]
 impl Aggregate for BankAccount {
     type Command = BankAccountCommand;
     type Event = BankAccountEvent;
@@ -33,7 +32,7 @@ impl Aggregate for BankAccount {
 
     // The aggregate logic goes here. Note that this will be the _bulk_ of a CQRS system
     // so expect to use helper functions elsewhere to keep the code clean.
-    async fn handle(&self, command: Self::Command, services: Self::Services) -> Result<Vec<Self::Event>, Self::Error> {
+    fn handle(&self, command: Self::Command, services: Self::Services) -> impl Future<Output = Result<Vec<Self::Event>, Self::Error>> + Send {
         todo!()
     }
 

--- a/persistence/dynamo-es/src/testing.rs
+++ b/persistence/dynamo-es/src/testing.rs
@@ -2,8 +2,8 @@
 pub(crate) mod tests {
     use std::collections::HashMap;
     use std::fmt::{Display, Formatter};
+    use std::future::Future;
 
-    use async_trait::async_trait;
     use aws_sdk_dynamodb::config::{Credentials, Region};
     use aws_sdk_dynamodb::Client;
     use cqrs_es::persist::{
@@ -23,7 +23,6 @@ pub(crate) mod tests {
         pub(crate) tests: Vec<String>,
     }
 
-    #[async_trait]
     impl Aggregate for TestAggregate {
         type Command = TestCommand;
         type Event = TestEvent;
@@ -34,12 +33,12 @@ pub(crate) mod tests {
             "TestAggregate".to_string()
         }
 
-        async fn handle(
+        fn handle(
             &self,
             _command: Self::Command,
             _services: &Self::Services,
-        ) -> Result<Vec<Self::Event>, Self::Error> {
-            Ok(vec![])
+        ) -> impl Future<Output = Result<Vec<Self::Event>, Self::Error>> + Send {
+            std::future::ready(Ok(vec![]))
         }
 
         fn apply(&mut self, _e: Self::Event) {}

--- a/persistence/postgres-es/src/testing.rs
+++ b/persistence/postgres-es/src/testing.rs
@@ -1,12 +1,12 @@
 #[cfg(test)]
 pub(crate) mod tests {
     use crate::PostgresViewRepository;
-    use async_trait::async_trait;
     use cqrs_es::persist::{GenericQuery, SerializedEvent, SerializedSnapshot};
     use cqrs_es::{Aggregate, DomainEvent, EventEnvelope, View};
     use serde::{Deserialize, Serialize};
     use serde_json::Value;
     use std::fmt::{Display, Formatter};
+    use std::future::Future;
 
     #[derive(Debug, Serialize, Deserialize, PartialEq, Default)]
     pub(crate) struct TestAggregate {
@@ -15,7 +15,6 @@ pub(crate) mod tests {
         pub(crate) tests: Vec<String>,
     }
 
-    #[async_trait]
     impl Aggregate for TestAggregate {
         type Command = TestCommand;
         type Event = TestEvent;
@@ -26,12 +25,12 @@ pub(crate) mod tests {
             "TestAggregate".to_string()
         }
 
-        async fn handle(
+        fn handle(
             &self,
             _command: Self::Command,
             _services: &Self::Services,
-        ) -> Result<Vec<Self::Event>, Self::Error> {
-            Ok(vec![])
+        ) -> impl Future<Output = Result<Vec<Self::Event>, Self::Error>> + Send {
+            std::future::ready(Ok(vec![]))
         }
 
         fn apply(&mut self, _e: Self::Event) {}

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,1 @@
+format_code_in_doc_comments = true

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,1 +1,0 @@
-format_code_in_doc_comments = true

--- a/src/aggregate.rs
+++ b/src/aggregate.rs
@@ -19,7 +19,6 @@ use crate::DomainEvent;
 /// # use cqrs_es::doc::{CustomerEvent, CustomerError, CustomerCommand, CustomerService};
 /// # use cqrs_es::{Aggregate, AggregateError};
 /// # use serde::{Serialize,Deserialize};
-/// # use async_trait::async_trait;
 /// # use std::future::Future;
 /// #[derive(Default, Serialize, Deserialize)]
 /// struct Customer {
@@ -78,7 +77,7 @@ pub trait Aggregate: Default + Serialize + DeserializeOwned + Sync + Send {
     type Event: DomainEvent;
     /// The error returned when a command fails due to business logic.
     /// This is used to provide feedback to the user as to the nature of why the command was refused.
-    type Error: std::error::Error;
+    type Error: std::error::Error + Send;
     /// The external services required for the logic within the Aggregate
     type Services: Send + Sync;
     /// The aggregate type is used as the unique identifier for this aggregate and its events.
@@ -96,7 +95,6 @@ pub trait Aggregate: Default + Serialize + DeserializeOwned + Sync + Send {
     /// use cqrs_es::{Aggregate, AggregateError};
     /// # use serde::{Serialize, Deserialize, de::DeserializeOwned};
     /// # use cqrs_es::doc::{CustomerCommand, CustomerError, CustomerEvent, CustomerService};
-    /// # use async_trait::async_trait;
     /// #[derive(Default, Serialize, Deserialize)]
     /// # struct Customer {
     /// #     name: Option<String>,
@@ -155,13 +153,11 @@ pub trait Aggregate: Default + Serialize + DeserializeOwned + Sync + Send {
     /// # use serde::{Serialize, Deserialize, de::DeserializeOwned};
     /// # use cqrs_es::doc::{CustomerCommand, CustomerError, CustomerEvent, CustomerService};
     /// use cqrs_es::{Aggregate, AggregateError};
-    /// use async_trait::async_trait;
     /// #[derive(Default,Serialize,Deserialize)]
     /// # struct Customer {
     /// #     name: Option<String>,
     /// #     email: Option<String>,
     /// # }
-    /// # #[async_trait]
     /// # impl Aggregate for Customer {
     /// #     type Command = CustomerCommand;
     /// #     type Event = CustomerEvent;

--- a/src/aggregate.rs
+++ b/src/aggregate.rs
@@ -1,4 +1,5 @@
-use async_trait::async_trait;
+use std::future::Future;
+
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 
@@ -63,7 +64,6 @@ use crate::DomainEvent;
 ///     }
 /// }
 /// ```
-#[async_trait]
 pub trait Aggregate: Default + Serialize + DeserializeOwned + Sync + Send {
     /// Specifies the inbound command used to make changes in the state of the Aggregate.
     type Command;
@@ -118,11 +118,11 @@ pub trait Aggregate: Default + Serialize + DeserializeOwned + Sync + Send {
     /// # fn apply(&mut self, event: Self::Event) {}
     /// # }
     /// ```
-    async fn handle(
+    fn handle(
         &self,
         command: Self::Command,
         service: &Self::Services,
-    ) -> Result<Vec<Self::Event>, Self::Error>;
+    ) -> impl Future<Output = Result<Vec<Self::Event>, Self::Error>> + Send;
     /// This is used to update the aggregate's state once an event has been committed.
     /// Any events returned from the `handle` method will be applied using this method
     /// in order to populate the state of the aggregate instance.

--- a/src/cqrs.rs
+++ b/src/cqrs.rs
@@ -18,7 +18,6 @@ use crate::{AggregateContext, AggregateError};
 /// 1. Persisting any generated events or roll back in the event of an error.
 ///
 /// To manage these tasks we use a `CqrsFramework`.
-///
 pub struct CqrsFramework<A, ES>
 where
     A: Aggregate,
@@ -43,8 +42,8 @@ where
     ///
     /// ```rust
     /// # use cqrs_es::doc::{MyAggregate, MyService};
-    /// use cqrs_es::CqrsFramework;
     /// use cqrs_es::mem_store::MemStore;
+    /// use cqrs_es::CqrsFramework;
     ///
     /// let store = MemStore::<MyAggregate>::default();
     /// let queries = vec![];
@@ -58,7 +57,6 @@ where
     /// - [PostgreSQL](https://www.postgresql.org/) - [postgres-es](https://crates.io/crates/postgres-es)
     /// - [MySQL](https://www.mysql.com/) - [mysql-es](https://crates.io/crates/mysql-es)
     /// - [DynamoDb](https://aws.amazon.com/dynamodb/) - [dynamo-es](https://crates.io/crates/dynamo-es)
-    ///
     pub fn new(store: ES, queries: Vec<Box<dyn Query<A>>>, service: A::Services) -> Self
     where
         A: Aggregate,
@@ -73,15 +71,15 @@ where
     /// Appends an additional query to the framework.
     /// ```rust
     /// # use cqrs_es::doc::{MyAggregate, MyQuery, MyService};
-    /// use cqrs_es::CqrsFramework;
     /// use cqrs_es::mem_store::MemStore;
+    /// use cqrs_es::CqrsFramework;
     ///
     /// let store = MemStore::<MyAggregate>::default();
     /// let queries = vec![];
     /// let service = MyService::default();
     ///
-    /// let cqrs = CqrsFramework::new(store, queries, service)
-    ///     .append_query(Box::new(MyQuery::default()));
+    /// let cqrs =
+    ///     CqrsFramework::new(store, queries, service).append_query(Box::new(MyQuery::default()));
     /// ```
     pub fn append_query(self, query: Box<dyn Query<A>>) -> Self
     where
@@ -113,9 +111,9 @@ where
     /// # use cqrs_es::mem_store::MemStore;
     /// # use std::collections::HashMap;
     /// # use chrono;
-    /// type MyFramework = CqrsFramework<MyAggregate,MemStore<MyAggregate>>;
+    /// type MyFramework = CqrsFramework<MyAggregate, MemStore<MyAggregate>>;
     ///
-    /// async fn do_something(cqrs: MyFramework) -> Result<(),AggregateError<MyUserError>> {
+    /// async fn do_something(cqrs: MyFramework) -> Result<(), AggregateError<MyUserError>> {
     ///     let command = MyCommands::DoSomething;
     ///
     ///     cqrs.execute("agg-id-F39A0C", command).await
@@ -154,13 +152,14 @@ where
     /// # use cqrs_es::mem_store::MemStore;
     /// # use std::collections::HashMap;
     /// # use chrono;
-    /// type MyFramework = CqrsFramework<MyAggregate,MemStore<MyAggregate>>;
+    /// type MyFramework = CqrsFramework<MyAggregate, MemStore<MyAggregate>>;
     ///
-    /// async fn do_something(cqrs: MyFramework) -> Result<(),AggregateError<MyUserError>>  {
+    /// async fn do_something(cqrs: MyFramework) -> Result<(), AggregateError<MyUserError>> {
     ///     let command = MyCommands::DoSomething;
     ///     let metadata = HashMap::from([("time".to_string(), chrono::Utc::now().to_rfc3339())]);
     ///
-    ///     cqrs.execute_with_metadata("agg-id-F39A0C", command, metadata).await
+    ///     cqrs.execute_with_metadata("agg-id-F39A0C", command, metadata)
+    ///         .await
     /// }
     /// ```
     pub async fn execute_with_metadata(

--- a/src/doc.rs
+++ b/src/doc.rs
@@ -166,47 +166,49 @@ pub enum CustomerCommand {
 }
 
 pub struct MyRepository;
-#[async_trait]
+
 impl PersistedEventRepository for MyRepository {
-    async fn get_events<A: Aggregate>(
+    fn get_events<A: Aggregate>(
         &self,
         _aggregate_id: &str,
-    ) -> Result<Vec<SerializedEvent>, PersistenceError> {
-        todo!()
+    ) -> impl Future<Output = Result<Vec<SerializedEvent>, PersistenceError>> + Send {
+        async { todo!() }
     }
 
-    async fn get_last_events<A: Aggregate>(
+    fn get_last_events<A: Aggregate>(
         &self,
         _aggregate_id: &str,
         _number_events: usize,
-    ) -> Result<Vec<SerializedEvent>, PersistenceError> {
-        todo!()
+    ) -> impl Future<Output = Result<Vec<SerializedEvent>, PersistenceError>> + Send {
+        async { todo!() }
     }
 
-    async fn get_snapshot<A: Aggregate>(
+    fn get_snapshot<A: Aggregate>(
         &self,
         _aggregate_id: &str,
-    ) -> Result<Option<SerializedSnapshot>, PersistenceError> {
-        todo!()
+    ) -> impl Future<Output = Result<Option<SerializedSnapshot>, PersistenceError>> + Send {
+        async { todo!() }
     }
 
-    async fn persist<A: Aggregate>(
+    fn persist<A: Aggregate>(
         &self,
         _events: &[SerializedEvent],
         _snapshot_update: Option<(String, Value, usize)>,
-    ) -> Result<(), PersistenceError> {
-        todo!()
+    ) -> impl Future<Output = Result<(), PersistenceError>> + Send {
+        async { todo!() }
     }
 
-    async fn stream_events<A: Aggregate>(
+    fn stream_events<A: Aggregate>(
         &self,
         _aggregate_id: &str,
-    ) -> Result<ReplayStream, PersistenceError> {
-        todo!()
+    ) -> impl Future<Output = Result<ReplayStream, PersistenceError>> + Send {
+        async { todo!() }
     }
 
-    async fn stream_all_events<A: Aggregate>(&self) -> Result<ReplayStream, PersistenceError> {
-        todo!()
+    fn stream_all_events<A: Aggregate>(
+        &self,
+    ) -> impl Future<Output = Result<ReplayStream, PersistenceError>> + Send {
+        async { todo!() }
     }
 }
 

--- a/src/event.rs
+++ b/src/event.rs
@@ -31,10 +31,10 @@ use crate::aggregate::Aggregate;
 /// # use cqrs_es::doc::Customer;
 /// # use cqrs_es::{Aggregate,DomainEvent};
 /// # use serde::{Serialize,Deserialize};
-/// #[derive(Clone,Debug,Serialize,Deserialize,PartialEq)]
+/// #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 /// pub enum CustomerEvent {
-///     NameChanged{ changed_name: String },
-///     EmailUpdated{ new_email: String },
+///     NameChanged { changed_name: String },
+///     EmailUpdated { new_email: String },
 /// }
 /// ```
 pub trait DomainEvent:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,8 +29,8 @@ pub mod doc;
 ///
 /// ```
 /// # use cqrs_es::doc::{MyAggregate, MyService};
-/// use cqrs_es::CqrsFramework;
 /// use cqrs_es::mem_store::MemStore;
+/// use cqrs_es::CqrsFramework;
 ///
 /// let store = MemStore::<MyAggregate>::default();
 /// let service = MyService::default();

--- a/src/mem_store.rs
+++ b/src/mem_store.rs
@@ -11,8 +11,8 @@ use crate::{Aggregate, AggregateContext, AggregateError, EventStore};
 /// Creation and use in a constructing a `CqrsFramework`:
 /// ```
 /// # use cqrs_es::doc::{MyAggregate, MyService};
-/// use cqrs_es::CqrsFramework;
 /// use cqrs_es::mem_store::MemStore;
+/// use cqrs_es::CqrsFramework;
 ///
 /// let store = MemStore::<MyAggregate>::default();
 /// let cqrs = CqrsFramework::new(store, vec![], MyService);

--- a/src/persist/doc.rs
+++ b/src/persist/doc.rs
@@ -1,3 +1,5 @@
+use std::future::Future;
+
 use crate::doc::MyAggregate;
 use crate::persist::event_stream::ReplayStream;
 use crate::persist::{
@@ -66,46 +68,47 @@ impl MyEventRepository {
     }
 }
 
-#[async_trait]
 impl PersistedEventRepository for MyEventRepository {
-    async fn get_events<A: Aggregate>(
+    fn get_events<A: Aggregate>(
         &self,
         _aggregate_id: &str,
-    ) -> Result<Vec<SerializedEvent>, PersistenceError> {
-        todo!()
+    ) -> impl Future<Output = Result<Vec<SerializedEvent>, PersistenceError>> + Send {
+        async { todo!() }
     }
 
-    async fn get_last_events<A: Aggregate>(
+    fn get_last_events<A: Aggregate>(
         &self,
         _aggregate_id: &str,
         _number_events: usize,
-    ) -> Result<Vec<SerializedEvent>, PersistenceError> {
-        todo!()
+    ) -> impl Future<Output = Result<Vec<SerializedEvent>, PersistenceError>> + Send {
+        async { todo!() }
     }
 
-    async fn get_snapshot<A: Aggregate>(
+    fn get_snapshot<A: Aggregate>(
         &self,
         _aggregate_id: &str,
-    ) -> Result<Option<SerializedSnapshot>, PersistenceError> {
-        todo!()
+    ) -> impl Future<Output = Result<Option<SerializedSnapshot>, PersistenceError>> + Send {
+        async { todo!() }
     }
 
-    async fn persist<A: Aggregate>(
+    fn persist<A: Aggregate>(
         &self,
         _events: &[SerializedEvent],
         _snapshot_update: Option<(String, Value, usize)>,
-    ) -> Result<(), PersistenceError> {
-        todo!()
+    ) -> impl Future<Output = Result<(), PersistenceError>> + Send {
+        async { todo!() }
     }
 
-    async fn stream_events<A: Aggregate>(
+    fn stream_events<A: Aggregate>(
         &self,
         _aggregate_id: &str,
-    ) -> Result<ReplayStream, PersistenceError> {
-        todo!()
+    ) -> impl Future<Output = Result<ReplayStream, PersistenceError>> + Send {
+        async { todo!() }
     }
 
-    async fn stream_all_events<A: Aggregate>(&self) -> Result<ReplayStream, PersistenceError> {
-        todo!()
+    fn stream_all_events<A: Aggregate>(
+        &self,
+    ) -> impl Future<Output = Result<ReplayStream, PersistenceError>> + Send {
+        async { todo!() }
     }
 }

--- a/src/persist/event_repository.rs
+++ b/src/persist/event_repository.rs
@@ -1,44 +1,46 @@
+use std::future::Future;
+
 use crate::persist::event_stream::ReplayStream;
 use crate::persist::{PersistenceError, SerializedEvent, SerializedSnapshot};
 use crate::Aggregate;
-use async_trait::async_trait;
 use serde_json::Value;
 
 /// Handles the database access needed for operation of a PersistedSnapshotStore.
-#[async_trait]
 pub trait PersistedEventRepository: Send + Sync {
     /// Returns all events for a single aggregate instance.
-    async fn get_events<A: Aggregate>(
+    fn get_events<A: Aggregate>(
         &self,
         aggregate_id: &str,
-    ) -> Result<Vec<SerializedEvent>, PersistenceError>;
+    ) -> impl Future<Output = Result<Vec<SerializedEvent>, PersistenceError>> + Send;
 
     /// Returns the last events for a single aggregate instance.
-    async fn get_last_events<A: Aggregate>(
+    fn get_last_events<A: Aggregate>(
         &self,
         aggregate_id: &str,
         last_sequence: usize,
-    ) -> Result<Vec<SerializedEvent>, PersistenceError>;
+    ) -> impl Future<Output = Result<Vec<SerializedEvent>, PersistenceError>> + Send;
 
     /// Returns the current snapshot for an aggregate instance.
-    async fn get_snapshot<A: Aggregate>(
+    fn get_snapshot<A: Aggregate>(
         &self,
         aggregate_id: &str,
-    ) -> Result<Option<SerializedSnapshot>, PersistenceError>;
+    ) -> impl Future<Output = Result<Option<SerializedSnapshot>, PersistenceError>> + Send;
 
     /// Commits the updated aggregate and accompanying events.
-    async fn persist<A: Aggregate>(
+    fn persist<A: Aggregate>(
         &self,
         events: &[SerializedEvent],
         snapshot_update: Option<(String, Value, usize)>,
-    ) -> Result<(), PersistenceError>;
+    ) -> impl Future<Output = Result<(), PersistenceError>> + Send;
 
     /// Streams all events for an aggregate instance.
-    async fn stream_events<A: Aggregate>(
+    fn stream_events<A: Aggregate>(
         &self,
         aggregate_id: &str,
-    ) -> Result<ReplayStream, PersistenceError>;
+    ) -> impl Future<Output = Result<ReplayStream, PersistenceError>> + Send;
 
     /// Streams all events for an aggregate type.
-    async fn stream_all_events<A: Aggregate>(&self) -> Result<ReplayStream, PersistenceError>;
+    fn stream_all_events<A: Aggregate>(
+        &self,
+    ) -> impl Future<Output = Result<ReplayStream, PersistenceError>> + Send;
 }

--- a/src/persist/event_store.rs
+++ b/src/persist/event_store.rs
@@ -99,7 +99,7 @@ where
     /// # use cqrs_es::persist::PersistedEventStore;
     /// # fn config(my_db_connection: MyDatabaseConnection) {
     /// let repo = MyEventRepository::new(my_db_connection);
-    /// let store = PersistedEventStore::<MyEventRepository,MyAggregate>::new_event_store(repo);
+    /// let store = PersistedEventStore::<MyEventRepository, MyAggregate>::new_event_store(repo);
     /// let service = MyService;
     /// let cqrs = CqrsFramework::new(store, vec![], service);
     /// # }
@@ -125,7 +125,7 @@ where
     /// # use cqrs_es::persist::PersistedEventStore;
     /// # fn config(my_db_connection: MyDatabaseConnection) {
     /// let repo = MyEventRepository::new(my_db_connection);
-    /// let store = PersistedEventStore::<MyEventRepository,MyAggregate>::new_aggregate_store(repo);
+    /// let store = PersistedEventStore::<MyEventRepository, MyAggregate>::new_aggregate_store(repo);
     /// let cqrs = CqrsFramework::new(store, vec![], MyService);
     /// # }
     /// ```
@@ -148,7 +148,8 @@ where
     /// # use cqrs_es::persist::PersistedEventStore;
     /// # fn config(my_db_connection: MyDatabaseConnection) {
     /// let repo = MyEventRepository::new(my_db_connection);
-    /// let store = PersistedEventStore::<MyEventRepository,MyAggregate>::new_snapshot_store(repo, 100);
+    /// let store =
+    ///     PersistedEventStore::<MyEventRepository, MyAggregate>::new_snapshot_store(repo, 100);
     /// let cqrs = CqrsFramework::new(store, vec![], MyService);
     /// # }
     /// ```

--- a/src/persist/event_store.rs
+++ b/src/persist/event_store.rs
@@ -323,7 +323,6 @@ pub(crate) mod shared_test {
     use std::future::Future;
     use std::sync::Mutex;
 
-    use async_trait::async_trait;
     use serde::{Deserialize, Serialize};
     use serde_json::Value;
 
@@ -460,7 +459,6 @@ pub(crate) mod shared_test {
         }
     }
 
-    #[async_trait]
     impl PersistedEventRepository for MockRepo {
         fn get_events<A: Aggregate>(
             &self,

--- a/src/persist/generic_query.rs
+++ b/src/persist/generic_query.rs
@@ -59,7 +59,7 @@ where
     /// # use cqrs_es::persist::GenericQuery;
     /// # use cqrs_es::persist::doc::{MyViewRepository,MyView};
     /// # fn config(mut query: GenericQuery<MyViewRepository,MyView,MyAggregate>) {
-    /// query.use_error_handler(Box::new(|e|panic!("{}",e)));
+    /// query.use_error_handler(Box::new(|e| panic!("{}", e)));
     /// # }
     /// ```
     pub fn use_error_handler(&mut self, error_handler: Box<QueryErrorHandler>) {
@@ -145,7 +145,7 @@ where
 /// }
 ///
 /// fn error_handler(error: PersistenceError) {
-///     panic!("{}",error);
+///     panic!("{}", error);
 /// }
 /// ```
 pub type QueryErrorHandler = dyn Fn(PersistenceError) + Send + Sync + 'static;

--- a/src/persist/mod.rs
+++ b/src/persist/mod.rs
@@ -6,7 +6,6 @@
 //! - [dynamo-es](https://crates.io/crates/dynamo-es)
 //!
 //!
-//!
 pub use context::EventStoreAggregateContext;
 pub use error::PersistenceError;
 pub use event_repository::PersistedEventRepository;

--- a/src/persist/replay.rs
+++ b/src/persist/replay.rs
@@ -69,7 +69,7 @@ where
     /// # use cqrs_es::doc::{MyAggregate, MyQuery, MyRepository};
     /// # use cqrs_es::persist::{GenericQuery, QueryReplay, ReplayStream};
     /// # fn config(mut replay: QueryReplay<MyRepository,MyQuery,MyAggregate>) {
-    /// replay.use_error_handler(Box::new(|e|panic!("{}",e)));
+    /// replay.use_error_handler(Box::new(|e| panic!("{}", e)));
     /// # }
     /// ```
     pub fn use_error_handler(&mut self, error_handler: Box<QueryErrorHandler>) {

--- a/src/persist/upcaster.rs
+++ b/src/persist/upcaster.rs
@@ -78,54 +78,56 @@ impl From<ParseIntError> for SemanticVersionError {
 /// version configured on the upcaster.
 ///
 /// ```
-/// use cqrs_es::persist::{EventUpcaster,SemanticVersionEventUpcaster};
-/// use serde_json::Value;
 /// use cqrs_es::persist::SerializedEvent;
+/// use cqrs_es::persist::{EventUpcaster, SemanticVersionEventUpcaster};
+/// use serde_json::Value;
 ///
 /// let upcast_function = Box::new(|payload: Value| match payload {
-///             Value::Object(mut object_map) => {
-///                 object_map.insert("country".to_string(), "USA".into());
-///                 Value::Object(object_map)
-///             }
-///             _ => {
-///                 panic!("the event payload is not an object")
-///             }
-///         });
+///     Value::Object(mut object_map) => {
+///         object_map.insert("country".to_string(), "USA".into());
+///         Value::Object(object_map)
+///     }
+///     _ => {
+///         panic!("the event payload is not an object")
+///     }
+/// });
 /// let upcaster = SemanticVersionEventUpcaster::new("EventX", "2.3.4", upcast_function);
 ///
 /// let payload: Value = serde_json::from_str(
-///             r#"{
+///     r#"{
 ///                     "zip code": 98103,
 ///                     "state": "Washington"
 ///                    }"#,
-///         ).unwrap();
-///  let event = SerializedEvent::new(
-///             String::new(),
-///             0,
-///             String::new(),
-///             String::new(),
-///             String::new(),
-///             payload,
-///             Default::default(),
-///         );
+/// )
+/// .unwrap();
+/// let event = SerializedEvent::new(
+///     String::new(),
+///     0,
+///     String::new(),
+///     String::new(),
+///     String::new(),
+///     payload,
+///     Default::default(),
+/// );
 /// let upcasted_event = upcaster.upcast(event);
 ///
 /// let expected_payload: Value = serde_json::from_str(
-///             r#"{
+///     r#"{
 ///                     "zip code": 98103,
 ///                     "state": "Washington",
 ///                     "country": "USA"
 ///                    }"#,
-///         ).unwrap();
+/// )
+/// .unwrap();
 /// let expected_event = SerializedEvent::new(
-///             String::new(),
-///             0,
-///             String::new(),
-///             String::new(),
-///             "2.3.4".to_string(),
-///             expected_payload,
-///             Default::default(),
-///         );
+///     String::new(),
+///     0,
+///     String::new(),
+///     String::new(),
+///     "2.3.4".to_string(),
+///     expected_payload,
+///     Default::default(),
+/// );
 ///
 /// assert_eq!(upcasted_event, expected_event);
 /// ```

--- a/src/query.rs
+++ b/src/query.rs
@@ -22,7 +22,6 @@ pub trait Query<A: Aggregate>: Send + Sync {
 
 /// A `View` represents a materialized view, generally serialized for persistence, that is updated by a query.
 /// This a read element in a CQRS system.
-///
 pub trait View<A: Aggregate>: Debug + Default + Serialize + DeserializeOwned + Send + Sync {
     /// Each implemented view is responsible for updating its state based on events passed via
     /// this method.

--- a/src/test/executor.rs
+++ b/src/test/executor.rs
@@ -20,8 +20,7 @@ where
     /// # use cqrs_es::doc::{MyAggregate, MyCommands, MyService};
     /// use cqrs_es::test::TestFramework;
     ///
-    /// let executor = TestFramework::<MyAggregate>::with(MyService)
-    ///     .given_no_previous_events();
+    /// let executor = TestFramework::<MyAggregate>::with(MyService).given_no_previous_events();
     ///
     /// let validator = executor.when(MyCommands::DoSomething);
     /// ```
@@ -41,8 +40,7 @@ where
     ///
     /// #[tokio::test]
     /// async fn test() {
-    ///     let executor = TestFramework::<MyAggregate>::with(MyService)
-    ///         .given_no_previous_events();
+    ///     let executor = TestFramework::<MyAggregate>::with(MyService).given_no_previous_events();
     ///
     ///     let validator = executor.when_async(MyCommands::DoSomething).await;
     /// }

--- a/src/test/framework.rs
+++ b/src/test/framework.rs
@@ -24,8 +24,7 @@ where
     /// # use cqrs_es::doc::{MyAggregate, MyService};
     /// use cqrs_es::test::TestFramework;
     ///
-    /// let executor = TestFramework::<MyAggregate>::with(MyService)
-    ///     .given_no_previous_events();
+    /// let executor = TestFramework::<MyAggregate>::with(MyService).given_no_previous_events();
     /// ```
     #[must_use]
     pub fn given_no_previous_events(self) -> AggregateTestExecutor<A> {
@@ -37,8 +36,8 @@ where
     /// # use cqrs_es::doc::{MyAggregate, MyEvents, MyService};
     /// use cqrs_es::test::TestFramework;
     ///
-    /// let executor = TestFramework::<MyAggregate>::with(MyService)
-    ///     .given(vec![MyEvents::SomethingWasDone]);
+    /// let executor =
+    ///     TestFramework::<MyAggregate>::with(MyService).given(vec![MyEvents::SomethingWasDone]);
     /// ```
     #[must_use]
     pub fn given(self, events: Vec<A::Event>) -> AggregateTestExecutor<A> {

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -11,13 +11,12 @@
 //!
 //! CustomerTestFramework::with(CustomerService::default())
 //!     .given_no_previous_events()
-//!     .when(CustomerCommand::AddCustomerName{
-//!             name: "John Doe".to_string()
-//!         })
-//!     .then_expect_events(vec![
-//!         CustomerEvent::NameAdded{
-//!             name: "John Doe".to_string()
-//!         }]);
+//!     .when(CustomerCommand::AddCustomerName {
+//!         name: "John Doe".to_string(),
+//!     })
+//!     .then_expect_events(vec![CustomerEvent::NameAdded {
+//!         name: "John Doe".to_string(),
+//!     }]);
 //! # }
 //! ```
 mod executor;

--- a/src/test/validator.rs
+++ b/src/test/validator.rs
@@ -63,7 +63,7 @@ impl<A: Aggregate> AggregateResultValidator<A> {
     ///     .when(MyCommands::BadCommand);
     ///
     /// let expected = MyUserError("the expected error message".to_string());
-    /// assert_eq!(expected,validator.inspect_result().unwrap_err());
+    /// assert_eq!(expected, validator.inspect_result().unwrap_err());
     /// ```
     pub fn inspect_result(self) -> Result<Vec<A::Event>, A::Error> {
         self.result


### PR DESCRIPTION
async-trait is no longer required since stable rust now supports returning `impl trait` from traits