### PR TITLE
update the 'View' trait

### DIFF
--- a/demo/src/config.rs
+++ b/demo/src/config.rs
@@ -12,7 +12,7 @@ pub fn cqrs_framework(
     pool: Pool<Postgres>,
 ) -> (
     Arc<PostgresCqrs<BankAccount>>,
-    Arc<PostgresViewRepository<BankAccountView, BankAccount>>,
+    Arc<PostgresViewRepository<BankAccountView>>,
 ) {
     // A very simple query that writes each event to stdout.
     let simple_query = SimpleLoggingQuery {};

--- a/demo/src/queries.rs
+++ b/demo/src/queries.rs
@@ -24,11 +24,8 @@ impl Query<BankAccount> for SimpleLoggingQuery {
 // Our second query, this one will be handled with Postgres `GenericQuery`
 // which will serialize and persist our view after it is updated. It also
 // provides a `load` method to deserialize the view on request.
-pub type AccountQuery = GenericQuery<
-    PostgresViewRepository<BankAccountView, BankAccount>,
-    BankAccountView,
-    BankAccount,
->;
+pub type AccountQuery =
+    GenericQuery<PostgresViewRepository<BankAccountView>, BankAccountView, BankAccount>;
 
 // The view for a BankAccount query, for a standard http application this should
 // be designed to reflect the response dto that will be returned to a user.

--- a/demo/src/queries.rs
+++ b/demo/src/queries.rs
@@ -57,9 +57,10 @@ impl LedgerEntry {
 // This updates the view with events as they are committed.
 // The logic should be minimal here, e.g., don't calculate the account balance,
 // design the events to carry the balance information instead.
-impl View<BankAccount> for BankAccountView {
-    fn update(&mut self, event: &EventEnvelope<BankAccount>) {
-        match &event.payload {
+impl View for BankAccountView {
+    type Event = BankAccountEvent;
+    fn apply(&mut self, event: &Self::Event) {
+        match event {
             BankAccountEvent::AccountOpened { account_id } => {
                 self.account_id = Some(account_id.clone());
             }

--- a/demo/src/state.rs
+++ b/demo/src/state.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 #[derive(Clone)]
 pub struct ApplicationState {
     pub cqrs: Arc<PostgresCqrs<BankAccount>>,
-    pub account_query: Arc<PostgresViewRepository<BankAccountView, BankAccount>>,
+    pub account_query: Arc<PostgresViewRepository<BankAccountView>>,
 }
 
 pub async fn new_application_state() -> ApplicationState {

--- a/docs/book/src/application_persisted_views.md
+++ b/docs/book/src/application_persisted_views.md
@@ -24,7 +24,7 @@ impl View<BankAccount> for BankAccountView {
 The view repositories use the same database connection as the event repositories, for `postgres-es` this is a database
 connection pool. 
 ```rust
-type MyViewRepository = PostgresViewRepository<MyView,MyAggregate>;
+type MyViewRepository = PostgresViewRepository<MyView>;
 
 fn configure_view_repository(db_pool: Pool<Postgres>) -> MyViewRepository {
     PostgresViewRepository::new("my_view_name", db_pool)

--- a/persistence/dynamo-es/src/testing.rs
+++ b/persistence/dynamo-es/src/testing.rs
@@ -94,7 +94,7 @@ pub(crate) mod tests {
     pub enum TestCommand {}
 
     pub(crate) type TestQueryRepository =
-        GenericQuery<DynamoViewRepository<TestView, TestAggregate>, TestView, TestAggregate>;
+        GenericQuery<DynamoViewRepository<TestView>, TestView, TestAggregate>;
 
     #[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
     pub(crate) struct TestView {

--- a/persistence/dynamo-es/src/testing.rs
+++ b/persistence/dynamo-es/src/testing.rs
@@ -10,7 +10,7 @@ pub(crate) mod tests {
         GenericQuery, PersistedEventRepository, PersistedEventStore, SerializedEvent,
         SerializedSnapshot,
     };
-    use cqrs_es::{Aggregate, DomainEvent, EventEnvelope, EventStore, View};
+    use cqrs_es::{Aggregate, DomainEvent, EventStore, View};
     use serde::{Deserialize, Serialize};
     use serde_json::Value;
 
@@ -101,9 +101,10 @@ pub(crate) mod tests {
         pub(crate) events: Vec<TestEvent>,
     }
 
-    impl View<TestAggregate> for TestView {
-        fn update(&mut self, event: &EventEnvelope<TestAggregate>) {
-            self.events.push(event.payload.clone());
+    impl View for TestView {
+        type Event = TestEvent;
+        fn apply(&mut self, event: &TestEvent) {
+            self.events.push(event.clone());
         }
     }
 

--- a/persistence/dynamo-es/src/view_repository.rs
+++ b/persistence/dynamo-es/src/view_repository.rs
@@ -25,12 +25,11 @@ where
     /// line example).
     ///
     /// ```
-    /// # use cqrs_es::doc::MyAggregate;
     /// # use cqrs_es::persist::doc::MyView;
     /// use aws_sdk_dynamodb::Client;
     /// use dynamo_es::DynamoViewRepository;
     ///
-    /// fn configure_view_repo(client: Client) -> DynamoViewRepository<MyView,MyAggregate> {
+    /// fn configure_view_repo(client: Client) -> DynamoViewRepository<MyView> {
     ///     DynamoViewRepository::new("my_view_table", client)
     /// }
     /// ```

--- a/persistence/dynamo-es/src/view_repository.rs
+++ b/persistence/dynamo-es/src/view_repository.rs
@@ -17,7 +17,7 @@ pub struct DynamoViewRepository<V, A> {
 
 impl<V, A> DynamoViewRepository<V, A>
 where
-    V: View<A>,
+    V: View<Event = A::Event>,
     A: Aggregate,
 {
     /// Creates a new `DynamoViewRepository` that will store serialized views in a DynamoDb table named
@@ -47,7 +47,7 @@ where
 #[async_trait]
 impl<V, A> ViewRepository<V, A> for DynamoViewRepository<V, A>
 where
-    V: View<A>,
+    V: View<Event = A::Event>,
     A: Aggregate,
 {
     async fn load(&self, view_id: &str) -> Result<Option<V>, PersistenceError> {

--- a/persistence/mysql-es/src/cqrs.rs
+++ b/persistence/mysql-es/src/cqrs.rs
@@ -71,7 +71,7 @@ where
 #[cfg(test)]
 mod test {
     use crate::testing::tests::{
-        TestAggregate, TestQueryRepository, TestServices, TestView, TEST_CONNECTION_STRING,
+        TestQueryRepository, TestServices, TestView, TEST_CONNECTION_STRING,
     };
     use crate::{default_mysql_pool, mysql_cqrs, MysqlViewRepository};
     use std::sync::Arc;
@@ -79,7 +79,7 @@ mod test {
     #[tokio::test]
     async fn test_valid_cqrs_framework() {
         let pool = default_mysql_pool(TEST_CONNECTION_STRING).await;
-        let repo = MysqlViewRepository::<TestView, TestAggregate>::new("test_view", pool.clone());
+        let repo = MysqlViewRepository::<TestView>::new("test_view", pool.clone());
         let query = TestQueryRepository::new(Arc::new(repo));
         let _ps = mysql_cqrs(pool, vec![Box::new(query)], TestServices);
     }

--- a/persistence/mysql-es/src/testing.rs
+++ b/persistence/mysql-es/src/testing.rs
@@ -2,7 +2,7 @@
 pub(crate) mod tests {
     use async_trait::async_trait;
     use cqrs_es::persist::{GenericQuery, SerializedEvent, SerializedSnapshot};
-    use cqrs_es::{Aggregate, DomainEvent, EventEnvelope, View};
+    use cqrs_es::{Aggregate, DomainEvent, View};
     use serde::{Deserialize, Serialize};
     use serde_json::Value;
     use std::fmt::{Display, Formatter};
@@ -94,9 +94,10 @@ pub(crate) mod tests {
         pub(crate) events: Vec<TestEvent>,
     }
 
-    impl View<TestAggregate> for TestView {
-        fn update(&mut self, event: &EventEnvelope<TestAggregate>) {
-            self.events.push(event.payload.clone());
+    impl View for TestView {
+        type Event = TestEvent;
+        fn apply(&mut self, event: &Self::Event) {
+            self.events.push(event.clone());
         }
     }
 

--- a/persistence/mysql-es/src/testing.rs
+++ b/persistence/mysql-es/src/testing.rs
@@ -87,7 +87,7 @@ pub(crate) mod tests {
     pub enum TestCommand {}
 
     pub(crate) type TestQueryRepository =
-        GenericQuery<MysqlViewRepository<TestView, TestAggregate>, TestView, TestAggregate>;
+        GenericQuery<MysqlViewRepository<TestView>, TestView, TestAggregate>;
 
     #[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
     pub(crate) struct TestView {

--- a/persistence/mysql-es/src/view_repository.rs
+++ b/persistence/mysql-es/src/view_repository.rs
@@ -46,7 +46,7 @@ where
             update_sql,
             select_sql,
             pool,
-            _phantom: Default::default(),
+            _phantom: PhantomData,
         }
     }
 }

--- a/persistence/mysql-es/src/view_repository.rs
+++ b/persistence/mysql-es/src/view_repository.rs
@@ -26,12 +26,11 @@ where
     /// before using this query repository (see `/db/init.sql` sql initialization file).
     ///
     /// ```
-    /// # use cqrs_es::doc::MyAggregate;
     /// # use cqrs_es::persist::doc::MyView;
     /// use sqlx::{MySql, Pool};
     /// use mysql_es::MysqlViewRepository;
     ///
-    /// fn configure_view_repo(pool: Pool<MySql>) -> MysqlViewRepository<MyView,MyAggregate> {
+    /// fn configure_view_repo(pool: Pool<MySql>) -> MysqlViewRepository<MyView> {
     ///     MysqlViewRepository::new("my_view_table", pool)
     /// }
     /// ```

--- a/persistence/mysql-es/src/view_repository.rs
+++ b/persistence/mysql-es/src/view_repository.rs
@@ -19,7 +19,7 @@ pub struct MysqlViewRepository<V, A> {
 
 impl<V, A> MysqlViewRepository<V, A>
 where
-    V: View<A>,
+    V: View<Event = A::Event>,
     A: Aggregate,
 {
     /// Creates a new `MysqlViewRepository` that will store serialized views in a MySql table named
@@ -54,7 +54,7 @@ where
 #[async_trait]
 impl<V, A> ViewRepository<V, A> for MysqlViewRepository<V, A>
 where
-    V: View<A>,
+    V: View<Event = A::Event>,
     A: Aggregate,
 {
     async fn load(&self, view_id: &str) -> Result<Option<V>, PersistenceError> {

--- a/persistence/mysql-es/tests/lib.rs
+++ b/persistence/mysql-es/tests/lib.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use cqrs_es::doc::{Customer, CustomerEvent};
 use cqrs_es::persist::{PersistedEventStore, SemanticVersionEventUpcaster};
 use cqrs_es::EventStore;
@@ -65,7 +67,7 @@ async fn simple_es_commit_and_load_test(
                 new_email: "email B".to_string(),
             }],
             context,
-            Default::default(),
+            HashMap::default(),
         )
         .await
         .unwrap();

--- a/persistence/postgres-es/src/cqrs.rs
+++ b/persistence/postgres-es/src/cqrs.rs
@@ -72,7 +72,7 @@ where
 #[cfg(test)]
 mod test {
     use crate::testing::tests::{
-        TestAggregate, TestQueryRepository, TestServices, TestView, TEST_CONNECTION_STRING,
+        TestQueryRepository, TestServices, TestView, TEST_CONNECTION_STRING,
     };
     use crate::{default_postgress_pool, postgres_cqrs, PostgresViewRepository};
     use std::sync::Arc;
@@ -80,8 +80,7 @@ mod test {
     #[tokio::test]
     async fn test_valid_cqrs_framework() {
         let pool = default_postgress_pool(TEST_CONNECTION_STRING).await;
-        let repo =
-            PostgresViewRepository::<TestView, TestAggregate>::new("test_view", pool.clone());
+        let repo = PostgresViewRepository::<TestView>::new("test_view", pool.clone());
         let query = TestQueryRepository::new(Arc::new(repo));
         let _ps = postgres_cqrs(pool, vec![Box::new(query)], TestServices);
     }

--- a/persistence/postgres-es/src/testing.rs
+++ b/persistence/postgres-es/src/testing.rs
@@ -87,7 +87,7 @@ pub(crate) mod tests {
     pub(crate) enum TestCommand {}
 
     pub(crate) type TestQueryRepository =
-        GenericQuery<PostgresViewRepository<TestView, TestAggregate>, TestView, TestAggregate>;
+        GenericQuery<PostgresViewRepository<TestView>, TestView, TestAggregate>;
 
     #[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
     pub(crate) struct TestView {

--- a/persistence/postgres-es/src/testing.rs
+++ b/persistence/postgres-es/src/testing.rs
@@ -3,7 +3,7 @@ pub(crate) mod tests {
     use crate::PostgresViewRepository;
     use async_trait::async_trait;
     use cqrs_es::persist::{GenericQuery, SerializedEvent, SerializedSnapshot};
-    use cqrs_es::{Aggregate, DomainEvent, EventEnvelope, View};
+    use cqrs_es::{Aggregate, DomainEvent, View};
     use serde::{Deserialize, Serialize};
     use serde_json::Value;
     use std::fmt::{Display, Formatter};
@@ -94,9 +94,10 @@ pub(crate) mod tests {
         pub(crate) events: Vec<TestEvent>,
     }
 
-    impl View<TestAggregate> for TestView {
-        fn update(&mut self, event: &EventEnvelope<TestAggregate>) {
-            self.events.push(event.payload.clone());
+    impl View for TestView {
+        type Event = TestEvent;
+        fn apply(&mut self, event: &Self::Event) {
+            self.events.push(event.clone());
         }
     }
 

--- a/persistence/postgres-es/src/view_repository.rs
+++ b/persistence/postgres-es/src/view_repository.rs
@@ -19,7 +19,7 @@ pub struct PostgresViewRepository<V, A> {
 
 impl<V, A> PostgresViewRepository<V, A>
 where
-    V: View<A>,
+    V: View<Event = A::Event>,
     A: Aggregate,
 {
     /// Creates a new `PostgresViewRepository` that will store serialized views in a Postgres table named
@@ -56,7 +56,7 @@ where
 #[async_trait]
 impl<V, A> ViewRepository<V, A> for PostgresViewRepository<V, A>
 where
-    V: View<A>,
+    V: View<Event = A::Event>,
     A: Aggregate,
 {
     async fn load(&self, view_id: &str) -> Result<Option<V>, PersistenceError> {

--- a/persistence/postgres-es/src/view_repository.rs
+++ b/persistence/postgres-es/src/view_repository.rs
@@ -26,12 +26,11 @@ where
     /// before using this query repository (see `/db/init.sql` sql initialization file).
     ///
     /// ```
-    /// # use cqrs_es::doc::MyAggregate;
     /// # use cqrs_es::persist::doc::MyView;
     /// use sqlx::{Pool, Postgres};
     /// use postgres_es::PostgresViewRepository;
     ///
-    /// fn configure_view_repo(pool: Pool<Postgres>) -> PostgresViewRepository<MyView,MyAggregate> {
+    /// fn configure_view_repo(pool: Pool<Postgres>) -> PostgresViewRepository<MyView> {
     ///     PostgresViewRepository::new("my_view_table", pool)
     /// }
     /// ```

--- a/src/persist/doc.rs
+++ b/src/persist/doc.rs
@@ -1,4 +1,4 @@
-use crate::doc::{MyAggregate, MyEvents};
+use crate::doc::MyEvents;
 use crate::persist::event_stream::ReplayStream;
 use crate::persist::{
     PersistedEventRepository, PersistenceError, SerializedEvent, SerializedSnapshot, ViewContext,
@@ -29,7 +29,7 @@ impl MyViewRepository {
 }
 
 #[async_trait]
-impl ViewRepository<MyView, MyAggregate> for MyViewRepository {
+impl ViewRepository<MyView> for MyViewRepository {
     async fn load(&self, _view_id: &str) -> Result<Option<MyView>, PersistenceError> {
         todo!()
     }

--- a/src/persist/doc.rs
+++ b/src/persist/doc.rs
@@ -1,10 +1,10 @@
-use crate::doc::MyAggregate;
+use crate::doc::{MyAggregate, MyEvents};
 use crate::persist::event_stream::ReplayStream;
 use crate::persist::{
     PersistedEventRepository, PersistenceError, SerializedEvent, SerializedSnapshot, ViewContext,
     ViewRepository,
 };
-use crate::{Aggregate, EventEnvelope, View};
+use crate::{Aggregate, View};
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -12,8 +12,9 @@ use serde_json::Value;
 #[derive(Debug, Default, Serialize, Deserialize)]
 pub struct MyView;
 
-impl View<MyAggregate> for MyView {
-    fn update(&mut self, _event: &EventEnvelope<MyAggregate>) {
+impl View for MyView {
+    type Event = MyEvents;
+    fn apply(&mut self, _event: &Self::Event) {
         todo!()
     }
 }

--- a/src/persist/generic_query.rs
+++ b/src/persist/generic_query.rs
@@ -10,7 +10,7 @@ use crate::{Aggregate, EventEnvelope, Query, View};
 /// and to return materialized views.
 pub struct GenericQuery<R, V, A>
 where
-    R: ViewRepository<V, A>,
+    R: ViewRepository<V>,
     V: View<Event = A::Event>,
     A: Aggregate,
 {
@@ -21,7 +21,7 @@ where
 
 impl<R, V, A> GenericQuery<R, V, A>
 where
-    R: ViewRepository<V, A>,
+    R: ViewRepository<V>,
     V: View<Event = A::Event>,
     A: Aggregate,
 {
@@ -118,7 +118,7 @@ where
 #[async_trait]
 impl<R, V, A> Query<A> for GenericQuery<R, V, A>
 where
-    R: ViewRepository<V, A>,
+    R: ViewRepository<V>,
     V: View<Event = A::Event>,
     A: Aggregate,
 {

--- a/src/persist/view_repository.rs
+++ b/src/persist/view_repository.rs
@@ -1,13 +1,12 @@
 use crate::persist::PersistenceError;
-use crate::{Aggregate, View};
+use crate::View;
 use async_trait::async_trait;
 
 /// Handles the database access needed for a GenericQuery.
 #[async_trait]
-pub trait ViewRepository<V, A>: Send + Sync
+pub trait ViewRepository<V>: Send + Sync
 where
-    V: View<Event = A::Event>,
-    A: Aggregate,
+    V: View,
 {
     /// Returns the current view instance.
     async fn load(&self, view_id: &str) -> Result<Option<V>, PersistenceError>;

--- a/src/persist/view_repository.rs
+++ b/src/persist/view_repository.rs
@@ -6,7 +6,7 @@ use async_trait::async_trait;
 #[async_trait]
 pub trait ViewRepository<V, A>: Send + Sync
 where
-    V: View<A>,
+    V: View<Event = A::Event>,
     A: Aggregate,
 {
     /// Returns the current view instance.

--- a/src/query.rs
+++ b/src/query.rs
@@ -23,8 +23,10 @@ pub trait Query<A: Aggregate>: Send + Sync {
 /// A `View` represents a materialized view, generally serialized for persistence, that is updated by a query.
 /// This a read element in a CQRS system.
 ///
-pub trait View<A: Aggregate>: Debug + Default + Serialize + DeserializeOwned + Send + Sync {
+pub trait View: Debug + Default + Serialize + DeserializeOwned + Send + Sync {
+    /// The event type that this view is constructed from
+    type Event;
     /// Each implemented view is responsible for updating its state based on events passed via
     /// this method.
-    fn update(&mut self, event: &EventEnvelope<A>);
+    fn apply(&mut self, event: &Self::Event);
 }


### PR DESCRIPTION
aligns the 'View' trait and the 'Aggregate' trait more closely.

the View trait seems to be a synonym for a projection. An Aggregate is really a special case of a projection (that also handles commands), so it makes sense for these to be aligned.

I would like to take this further and have the Aggregate trait 'inherit' the View trait, but there are a couple of inconsistencies

1. the Aggregate events must implement DomainEvent, which supports the upcasting framework in this library, but the View event does not need to implement DomainEvent and hence doesn't support upcasting. What's the reason for this inconsistency?
2. the View does not have a 'type' String, does this mean view snapshots are not persisted, or are persisted using a different mechanism to aggregates?
3. i couldn't see any good reason why the Aggregate ingests Events and the View ingests wrapped EventEnvelopes. By design, the View should not need any additional metadata to reconstitute the state from the events, so i'm not sure this makes sense

i think this PR stands up even without resolving the above questions, but if they can be resolved than the `Aggregate` trait can be changed from

```rust
pub trait Aggregate: Default + Serialize + DeserializeOwned + Sync + Send {
    /// Specifies the inbound command used to make changes in the state of the Aggregate.
    type Command;
    /// Specifies the published events representing some change in state of the Aggregate.
    type Event: DomainEvent;
    /// The error returned when a command fails due to business logic.
    /// This is used to provide feedback to the user as to the nature of why the command was refused.
    type Error: std::error::Error;
    /// The external services required for the logic within the Aggregate
    type Services: Send + Sync;
   /// ...
}
```

to

```rust
pub trait Aggregate: View {
    /// Specifies the inbound command used to make changes in the state of the Aggregate.
    type Command;
    /// The error returned when a command fails due to business logic.
    /// This is used to provide feedback to the user as to the nature of why the command was refused.
    type Error: std::error::Error;
    /// The external services required for the logic within the Aggregate
    type Services: Send + Sync;
   /// ...
}
```