### PR TITLE
treat lockfile as binary

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+Cargo.lock binary


### PR DESCRIPTION
telling git to treat the lockfile as binary forces git to treat all changes to the lockfile as atomic and prevents it trying to merge lockfile changes (which can result in errors and is never what you want)