### PR TITLE
Remove unneeded uses of 'async-trait'

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -305,9 +305,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sigv4"
-version = "1.2.8"
+version = "1.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bc5bbd1e4a2648fd8c5982af03935972c24a2f9846b396de661d351ee3ce837"
+checksum = "9bfe75fad52793ce6dec0dc3d4b1f388f038b5eb866c8d4d7f3a8e21b5ea5051"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-http",
@@ -479,7 +479,7 @@ dependencies = [
  "http 1.2.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.5.2",
+ "hyper 1.6.0",
  "hyper-util",
  "itoa",
  "matchit",
@@ -602,9 +602,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.16.0"
+version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
+checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
 
 [[package]]
 name = "byteorder"
@@ -614,9 +614,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
+checksum = "f61dac84819c6588b558454b194026eb1f09c293b9036ae9b159e74e73ab6cf9"
 dependencies = [
  "serde",
 ]
@@ -633,9 +633,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.10"
+version = "1.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13208fcbb66eaeffe09b99fffbe1af420f00a7b35aa99ad683dfc1aa76145229"
+checksum = "c736e259eea577f443d5c86c304f9f4ae0295c43f3ba05c21f1d66b5f06001af"
 dependencies = [
  "shlex",
 ]
@@ -648,14 +648,14 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.39"
+version = "0.4.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e36cc9d416881d2e24f9a963be5fb1cd90966419ac844274161d10488b3e825"
+checksum = "1a7964611d71df112cb1730f2ee67324fcf4d0fc6606acbbe9bfe06df124637c"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
  "num-traits",
- "windows-targets 0.52.6",
+ "windows-link",
 ]
 
 [[package]]
@@ -691,9 +691,9 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16b80225097f2e5ae4e7179dd2266824648f3e2f49d9134d584b76389d31c4c3"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
 ]
@@ -821,7 +821,6 @@ checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 name = "dynamo-es"
 version = "0.4.12"
 dependencies = [
- "async-trait",
  "aws-sdk-dynamodb",
  "cqrs-es",
  "serde",
@@ -833,9 +832,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.13.0"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+checksum = "b7914353092ddf589ad78f25c5c1c21b7f80b0ff8621e7c814c3485b5306da9d"
 dependencies = [
  "serde",
 ]
@@ -851,9 +850,9 @@ dependencies = [
 
 [[package]]
 name = "equivalent"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
@@ -1302,9 +1301,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.9.5"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d71d3574edd2771538b901e6549113b4006ece66150fb69c0fb6d9a2adae946"
+checksum = "f2d708df4e7140240a16cd6ab0ab65c972d7433ab77819ea693fde9c43811e2a"
 
 [[package]]
 name = "httpdate"
@@ -1338,9 +1337,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.5.2"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "256fb8d4bd6413123cc9d91832d78325c48ff41677595be797d90f42969beae0"
+checksum = "cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1383,7 +1382,7 @@ dependencies = [
  "futures-util",
  "http 1.2.0",
  "http-body 1.0.1",
- "hyper 1.5.2",
+ "hyper 1.6.0",
  "pin-project-lite",
  "socket2 0.5.8",
  "tokio",
@@ -1623,7 +1622,7 @@ dependencies = [
  "http 1.2.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.5.2",
+ "hyper 1.6.0",
  "lambda_runtime",
  "mime",
  "percent-encoding",
@@ -1649,7 +1648,7 @@ dependencies = [
  "http-body 1.0.1",
  "http-body-util",
  "http-serde",
- "hyper 1.5.2",
+ "hyper 1.6.0",
  "hyper-util",
  "lambda_runtime_api_client",
  "pin-project",
@@ -1675,7 +1674,7 @@ dependencies = [
  "http 1.2.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.5.2",
+ "hyper 1.6.0",
  "hyper-util",
  "tokio",
  "tower 0.4.13",
@@ -1695,9 +1694,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.169"
+version = "0.2.170"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+checksum = "875b3680cb2f8f71bdcf9a30f38d48282f5d3c95cbf9b3fa57269bb5d5c06828"
 
 [[package]]
 name = "libm"
@@ -1729,9 +1728,9 @@ checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "litemap"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
+checksum = "23fb14cb19457329c82206317a5663005a4d404783dc74f4252769b0d5f42856"
 
 [[package]]
 name = "lock_api"
@@ -1745,9 +1744,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.25"
+version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
+checksum = "30bde2b3dc3671ae49d8e2e9f044c7c005836e7a023ee57cffa25ab82764bb9e"
 dependencies = [
  "value-bag",
 ]
@@ -1791,9 +1790,9 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.3"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8402cab7aefae129c6977bb0ff1b8fd9a04eb5b51efc50a70bea51cda0c7924"
+checksum = "8e3e04debbb59698c15bacbb6d93584a8c0ca9cc3213cb423d31f760d8843ce5"
 dependencies = [
  "adler2",
 ]
@@ -1813,7 +1812,6 @@ dependencies = [
 name = "mysql-es"
 version = "0.4.12"
 dependencies = [
- "async-trait",
  "cqrs-es",
  "futures",
  "serde",
@@ -1826,9 +1824,9 @@ dependencies = [
 
 [[package]]
 name = "native-tls"
-version = "0.2.12"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8614eb2c83d59d1c8cc974dd3f920198647674a0a035e1af1fa58707e317466"
+checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
 dependencies = [
  "libc",
  "log",
@@ -1905,15 +1903,15 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.20.2"
+version = "1.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
+checksum = "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e"
 
 [[package]]
 name = "openssl"
-version = "0.10.68"
+version = "0.10.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6174bc48f102d208783c2c84bf931bb75927a617866870de8a4ea85597f871f5"
+checksum = "5e14130c6a98cd258fdcb0fb6d744152343ff729cbfcb28c656a9d12b999fbcd"
 dependencies = [
  "bitflags 2.8.0",
  "cfg-if",
@@ -1937,15 +1935,15 @@ dependencies = [
 
 [[package]]
 name = "openssl-probe"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.104"
+version = "0.9.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45abf306cbf99debc8195b66b7346498d7b10c210de50418b5ccd7ceba08c741"
+checksum = "8bb61ea9811cc39e3c2069f40b8b8e2e70d8569b361f879786cc7ed48b777cdd"
 dependencies = [
  "cc",
  "libc",
@@ -2005,18 +2003,18 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pin-project"
-version = "1.1.8"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e2ec53ad785f4d35dac0adea7f7dc6f1bb277ad84a680c7afefeae05d1f5916"
+checksum = "dfe2e71e1471fe07709406bf725f710b02927c9c54b2b5b2ec0e8087d97c327d"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.8"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d56a66c0c55993aa927429d0f8a0abfd74f084e4d9c192cffed01e418d83eefb"
+checksum = "f6e859e6e5bd50440ab63c47e3ebabc90f26251f7c73c3d3e837b74a1cc3fa67"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2108,7 +2106,6 @@ dependencies = [
 name = "postgres-es"
 version = "0.4.12"
 dependencies = [
- "async-trait",
  "cqrs-es",
  "futures",
  "serde",
@@ -2195,9 +2192,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.8"
+version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
+checksum = "82b568323e98e49e2a0899dcee453dd679fae22d69adf9b11dd508d1549b7e2f"
 dependencies = [
  "bitflags 2.8.0",
 ]
@@ -2254,15 +2251,14 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "ring"
-version = "0.17.8"
+version = "0.17.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
+checksum = "da5349ae27d3887ca812fb375b45a4fbb36d8d12d2df394968cd86e35683fe73"
 dependencies = [
  "cc",
  "cfg-if",
  "getrandom 0.2.15",
  "libc",
- "spin",
  "untrusted",
  "windows-sys 0.52.0",
 ]
@@ -2343,9 +2339,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.21"
+version = "0.23.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f287924602bf649d949c63dc8ac8b235fa5387d394020705b80c4eb597ce5b8"
+checksum = "47796c98c480fce5406ef69d1c76378375492c3b0a0de587be0c1d9feb12f395"
 dependencies = [
  "once_cell",
  "ring",
@@ -2387,9 +2383,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2bf47e6ff922db3825eb750c4e2ff784c6ff8fb9e13046ef6a1d1c5401b0b37"
+checksum = "917ce264624a4b4db1c364dcc35bfca9ded014d0a958cd47ad3e960e988ea51c"
 
 [[package]]
 name = "rustls-webpki"
@@ -2420,9 +2416,9 @@ checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
 
 [[package]]
 name = "ryu"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+checksum = "6ea1a2d0a644769cc99faa24c3ad26b379b786fe7c36fd3c546254801650e6dd"
 
 [[package]]
 name = "schannel"
@@ -2480,18 +2476,18 @@ checksum = "f79dfe2d285b0488816f30e700a7438c5a73d816b5b7d3ac72fbc48b0d185e03"
 
 [[package]]
 name = "serde"
-version = "1.0.217"
+version = "1.0.218"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70"
+checksum = "e8dfc9d19bdbf6d17e22319da49161d5d0108e4188e8b680aef6299eed22df60"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.217"
+version = "1.0.218"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
+checksum = "f09503e191f4e797cb8aac08e9a4a4695c5edf6a2e70e376d961ddd5c969f82b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2500,9 +2496,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.138"
+version = "1.0.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d434192e7da787e94a6ea7e9670b26a036d0ca41e0b7efb2676dd32bae872949"
+checksum = "44f86c3acccc9c65b153fe1b85a3be07fe5515274ec9f0653b4a0875731c72a6"
 dependencies = [
  "itoa",
  "memchr",
@@ -2599,9 +2595,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.13.2"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+checksum = "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd"
 dependencies = [
  "serde",
 ]
@@ -2683,7 +2679,7 @@ dependencies = [
  "native-tls",
  "once_cell",
  "percent-encoding",
- "rustls 0.23.21",
+ "rustls 0.23.23",
  "rustls-pemfile 2.2.0",
  "serde",
  "serde_json",
@@ -2864,9 +2860,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.96"
+version = "2.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5d0adab1ae378d7f53bdebc67a39f1f151407ef230f0ce2883572f5d8985c80"
+checksum = "36147f1a48ae0ec2b5b3bc5b537d267457555a10dc06f3dbc8cb11ba3006d3b1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2892,13 +2888,13 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.15.0"
+version = "3.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8a559c81686f576e8cd0290cd2a24a2a9ad80c98b3478856500fcbd7acd704"
+checksum = "22e5a0acb1f3f55f65cc4a866c361b2fb2a0ff6366785ae6fbb5f85df07ba230"
 dependencies = [
  "cfg-if",
  "fastrand 2.3.0",
- "getrandom 0.2.15",
+ "getrandom 0.3.1",
  "once_cell",
  "rustix 0.38.44",
  "windows-sys 0.59.0",
@@ -3164,9 +3160,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typenum"
-version = "1.17.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
 
 [[package]]
 name = "unicode-bidi"
@@ -3176,9 +3172,9 @@ checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.14"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
+checksum = "00e2473a93778eb0bad35909dff6a10d28e63f792f16ed15e404fca9d5eeedbe"
 
 [[package]]
 name = "unicode-normalization"
@@ -3382,9 +3378,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.26.7"
+version = "0.26.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d642ff16b7e79272ae451b7322067cdc17cadf68c23264be9d94a32319efe7e"
+checksum = "2210b291f7ea53617fbafcc4939f10914214ec15aace5ba62293a668f322c5c9"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -3429,6 +3425,12 @@ checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
  "windows-targets 0.52.6",
 ]
+
+[[package]]
+name = "windows-link"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dccfd733ce2b1753b03b6d3c65edf020262ea35e20ccdf3e288043e6dd620e3"
 
 [[package]]
 name = "windows-sys"
@@ -3646,18 +3648,18 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cff3ee08c995dee1859d998dea82f7374f2826091dd9cd47def953cae446cd2e"
+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/demo/src/domain/aggregate.rs
+++ b/demo/src/domain/aggregate.rs
@@ -1,4 +1,3 @@
-use async_trait::async_trait;
 use cqrs_es::Aggregate;
 use serde::{Deserialize, Serialize};
 
@@ -12,7 +11,6 @@ pub struct BankAccount {
     balance: f64,
 }
 
-#[async_trait]
 impl Aggregate for BankAccount {
     // This identifier should be unique to the system.
     const TYPE: &'static str = "account";

--- a/docs/book/src/intro_add_aggregate.md
+++ b/docs/book/src/intro_add_aggregate.md
@@ -19,7 +19,6 @@ In order to operate within the `cqrs-es` framework, we will need the traits, `De
 (all usually derived) and we will implement `cqrs_es::Aggregate`, minus any of the business logic. 
 
 ```rust
-#[async_trait]
 impl Aggregate for BankAccount {
     type Command = BankAccountCommand;
     type Event = BankAccountEvent;

--- a/persistence/dynamo-es/Cargo.toml
+++ b/persistence/dynamo-es/Cargo.toml
@@ -12,7 +12,6 @@ readme = "README.md"
 
 [dependencies]
 cqrs-es.workspace = true
-async-trait = "0.1"
 aws-sdk-dynamodb = "1.66"
 serde = { workspace = true, features = ["derive"]}
 serde_json = "1.0"

--- a/persistence/dynamo-es/src/event_repository.rs
+++ b/persistence/dynamo-es/src/event_repository.rs
@@ -1,6 +1,5 @@
 use std::collections::HashMap;
 
-use async_trait::async_trait;
 use aws_sdk_dynamodb::operation::query::builders::QueryFluentBuilder;
 use aws_sdk_dynamodb::operation::query::QueryOutput;
 use aws_sdk_dynamodb::operation::scan::builders::ScanFluentBuilder;
@@ -271,7 +270,6 @@ fn serialized_event(
     })
 }
 
-#[async_trait]
 impl PersistedEventRepository for DynamoEventRepository {
     async fn get_events<A: Aggregate>(
         &self,

--- a/persistence/dynamo-es/src/testing.rs
+++ b/persistence/dynamo-es/src/testing.rs
@@ -3,7 +3,6 @@ pub(crate) mod tests {
     use std::collections::HashMap;
     use std::fmt::{Display, Formatter};
 
-    use async_trait::async_trait;
     use aws_sdk_dynamodb::config::{Credentials, Region};
     use aws_sdk_dynamodb::Client;
     use cqrs_es::persist::{
@@ -23,7 +22,6 @@ pub(crate) mod tests {
         pub(crate) tests: Vec<String>,
     }
 
-    #[async_trait]
     impl Aggregate for TestAggregate {
         const TYPE: &'static str = "TestAggregate";
         type Command = TestCommand;

--- a/persistence/mysql-es/Cargo.toml
+++ b/persistence/mysql-es/Cargo.toml
@@ -12,7 +12,6 @@ readme = "README.md"
 
 [dependencies]
 cqrs-es.workspace = true
-async-trait = "0.1"
 futures = "0.3"
 serde = { workspace = true, features = ["derive"]}
 serde_json = "1.0"

--- a/persistence/mysql-es/src/event_repository.rs
+++ b/persistence/mysql-es/src/event_repository.rs
@@ -1,4 +1,3 @@
-use async_trait::async_trait;
 use cqrs_es::persist::{
     PersistedEventRepository, PersistenceError, ReplayFeed, ReplayStream, SerializedEvent,
     SerializedSnapshot,
@@ -25,7 +24,6 @@ pub struct MysqlEventRepository {
     stream_channel_size: usize,
 }
 
-#[async_trait]
 impl PersistedEventRepository for MysqlEventRepository {
     async fn get_events<A: Aggregate>(
         &self,

--- a/persistence/mysql-es/src/testing.rs
+++ b/persistence/mysql-es/src/testing.rs
@@ -1,6 +1,5 @@
 #[cfg(test)]
 pub(crate) mod tests {
-    use async_trait::async_trait;
     use cqrs_es::persist::{GenericQuery, SerializedEvent, SerializedSnapshot};
     use cqrs_es::{Aggregate, DomainEvent, EventEnvelope, View};
     use serde::{Deserialize, Serialize};
@@ -16,7 +15,6 @@ pub(crate) mod tests {
         pub(crate) tests: Vec<String>,
     }
 
-    #[async_trait]
     impl Aggregate for TestAggregate {
         const TYPE: &'static str = "TestAggregate";
         type Command = TestCommand;

--- a/persistence/mysql-es/src/view_repository.rs
+++ b/persistence/mysql-es/src/view_repository.rs
@@ -1,6 +1,5 @@
 use std::marker::PhantomData;
 
-use async_trait::async_trait;
 use cqrs_es::persist::{PersistenceError, ViewContext, ViewRepository};
 use cqrs_es::{Aggregate, View};
 use sqlx::mysql::MySqlRow;
@@ -51,7 +50,6 @@ where
     }
 }
 
-#[async_trait]
 impl<V, A> ViewRepository<V, A> for MysqlViewRepository<V, A>
 where
     V: View<A>,

--- a/persistence/postgres-es/Cargo.toml
+++ b/persistence/postgres-es/Cargo.toml
@@ -12,7 +12,6 @@ readme = "README.md"
 
 [dependencies]
 cqrs-es.workspace = true
-async-trait = "0.1"
 futures = "0.3"
 serde = { workspace = true, features = ["derive"] }
 serde_json = "1.0"

--- a/persistence/postgres-es/src/event_repository.rs
+++ b/persistence/postgres-es/src/event_repository.rs
@@ -1,4 +1,3 @@
-use async_trait::async_trait;
 use cqrs_es::persist::{
     PersistedEventRepository, PersistenceError, ReplayStream, SerializedEvent, SerializedSnapshot,
 };
@@ -23,7 +22,6 @@ pub struct PostgresEventRepository {
     stream_channel_size: usize,
 }
 
-#[async_trait]
 impl PersistedEventRepository for PostgresEventRepository {
     async fn get_events<A: Aggregate>(
         &self,

--- a/persistence/postgres-es/src/testing.rs
+++ b/persistence/postgres-es/src/testing.rs
@@ -1,7 +1,6 @@
 #[cfg(test)]
 pub(crate) mod tests {
     use crate::PostgresViewRepository;
-    use async_trait::async_trait;
     use cqrs_es::persist::{GenericQuery, SerializedEvent, SerializedSnapshot};
     use cqrs_es::{Aggregate, DomainEvent, EventEnvelope, View};
     use serde::{Deserialize, Serialize};
@@ -15,7 +14,6 @@ pub(crate) mod tests {
         pub(crate) tests: Vec<String>,
     }
 
-    #[async_trait]
     impl Aggregate for TestAggregate {
         const TYPE: &'static str = "TestAggregate";
         type Command = TestCommand;

--- a/persistence/postgres-es/src/view_repository.rs
+++ b/persistence/postgres-es/src/view_repository.rs
@@ -1,6 +1,5 @@
 use std::marker::PhantomData;
 
-use async_trait::async_trait;
 use cqrs_es::persist::{PersistenceError, ViewContext, ViewRepository};
 use cqrs_es::{Aggregate, View};
 use sqlx::postgres::PgRow;
@@ -53,7 +52,6 @@ where
     }
 }
 
-#[async_trait]
 impl<V, A> ViewRepository<V, A> for PostgresViewRepository<V, A>
 where
     V: View<A>,

--- a/src/aggregate.rs
+++ b/src/aggregate.rs
@@ -19,14 +19,12 @@ use crate::DomainEvent;
 /// # use cqrs_es::doc::{CustomerEvent, CustomerError, CustomerCommand, CustomerService};
 /// # use cqrs_es::{Aggregate, AggregateError};
 /// # use serde::{Serialize,Deserialize};
-/// # use async_trait::async_trait;
 /// #[derive(Default,Serialize,Deserialize)]
 /// struct Customer {
 ///     name: Option<String>,
 ///     email: Option<String>,
 /// }
 ///
-/// #[async_trait]
 /// impl Aggregate for Customer {
 ///     const TYPE: &'static str = "customer";
 ///     type Command = CustomerCommand;
@@ -87,13 +85,11 @@ pub trait Aggregate: Default + Serialize + DeserializeOwned + Sync + Send {
     /// use cqrs_es::{Aggregate, AggregateError};
     /// # use serde::{Serialize, Deserialize, de::DeserializeOwned};
     /// # use cqrs_es::doc::{CustomerCommand, CustomerError, CustomerEvent, CustomerService};
-    /// # use async_trait::async_trait;
     /// #[derive(Default,Serialize,Deserialize)]
     /// # struct Customer {
     /// #     name: Option<String>,
     /// #     email: Option<String>,
     /// # }
-    /// # #[async_trait]
     /// # impl Aggregate for Customer {
     /// #     const TYPE: &'static str = "customer";
     /// #     type Command = CustomerCommand;
@@ -140,13 +136,11 @@ pub trait Aggregate: Default + Serialize + DeserializeOwned + Sync + Send {
     /// # use serde::{Serialize, Deserialize, de::DeserializeOwned};
     /// # use cqrs_es::doc::{CustomerCommand, CustomerError, CustomerEvent, CustomerService};
     /// use cqrs_es::{Aggregate, AggregateError};
-    /// use async_trait::async_trait;
     /// #[derive(Default,Serialize,Deserialize)]
     /// # struct Customer {
     /// #     name: Option<String>,
     /// #     email: Option<String>,
     /// # }
-    /// # #[async_trait]
     /// # impl Aggregate for Customer {
     /// #     const TYPE: &'static str = "customer";
     /// #     type Command = CustomerCommand;

--- a/src/aggregate.rs
+++ b/src/aggregate.rs
@@ -1,4 +1,5 @@
-use async_trait::async_trait;
+use std::future::Future;
+
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 
@@ -61,7 +62,6 @@ use crate::DomainEvent;
 ///     }
 /// }
 /// ```
-#[async_trait]
 pub trait Aggregate: Default + Serialize + DeserializeOwned + Sync + Send {
     /// The aggregate type is used as the unique identifier for this aggregate and its events.
     /// This is used for persisting the events and snapshots to a database.
@@ -117,11 +117,11 @@ pub trait Aggregate: Default + Serialize + DeserializeOwned + Sync + Send {
     /// # fn apply(&mut self, event: Self::Event) {}
     /// # }
     /// ```
-    async fn handle(
+    fn handle(
         &self,
         command: Self::Command,
         service: &Self::Services,
-    ) -> Result<Vec<Self::Event>, Self::Error>;
+    ) -> impl Future<Output = Result<Vec<Self::Event>, Self::Error>> + Send;
     /// This is used to update the aggregate's state once an event has been committed.
     /// Any events returned from the `handle` method will be applied using this method
     /// in order to populate the state of the aggregate instance.
@@ -130,7 +130,7 @@ pub trait Aggregate: Default + Serialize + DeserializeOwned + Sync + Send {
     /// applied to an aggregate:
     /// - event sourced - All events are applied every time the aggregate is loaded.
     /// - aggregate sourced - Events are applied immediately after they are returned from `handle`
-    /// (and before they are committed) and the resulting aggregate instance is serialized and persisted.
+    ///   (and before they are committed) and the resulting aggregate instance is serialized and persisted.
     /// - snapshots - Uses a combination of the above patterns.
     ///
     /// _No business logic should be placed here_, this is only used for updating the aggregate state.

--- a/src/doc.rs
+++ b/src/doc.rs
@@ -156,7 +156,7 @@ pub enum CustomerCommand {
 }
 
 pub struct MyRepository;
-#[async_trait]
+
 impl PersistedEventRepository for MyRepository {
     async fn get_events<A: Aggregate>(
         &self,

--- a/src/doc.rs
+++ b/src/doc.rs
@@ -1,5 +1,3 @@
-use std::future::Future;
-
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -86,12 +84,12 @@ impl Aggregate for Customer {
     type Error = CustomerError;
     type Services = CustomerService;
 
-    fn handle(
+    async fn handle(
         &self,
         command: Self::Command,
         _service: &Self::Services,
-    ) -> impl Future<Output = Result<Vec<Self::Event>, Self::Error>> + Send {
-        std::future::ready(match command {
+    ) -> Result<Vec<Self::Event>, Self::Error> {
+        match command {
             CustomerCommand::AddCustomerName { .. } if self.name.as_str() != "" => {
                 Err("a name has already been added for this customer".into())
             }
@@ -101,7 +99,7 @@ impl Aggregate for Customer {
             CustomerCommand::UpdateEmail { new_email } => {
                 Ok(vec![CustomerEvent::EmailUpdated { new_email }])
             }
-        })
+        }
     }
 
     fn apply(&mut self, event: Self::Event) {

--- a/src/doc.rs
+++ b/src/doc.rs
@@ -79,7 +79,6 @@ impl Query<MyAggregate> for MyQuery {
     async fn dispatch(&self, _aggregate_id: &str, _events: &[EventEnvelope<MyAggregate>]) {}
 }
 
-#[async_trait]
 impl Aggregate for Customer {
     const TYPE: &'static str = "Customer";
     type Command = CustomerCommand;

--- a/src/mem_store.rs
+++ b/src/mem_store.rs
@@ -1,8 +1,6 @@
 use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
 
-use async_trait::async_trait;
-
 use crate::event::EventEnvelope;
 use crate::{Aggregate, AggregateContext, AggregateError, EventStore};
 
@@ -79,7 +77,6 @@ impl<A: Aggregate> MemStore<A> {
     }
 }
 
-#[async_trait]
 impl<A: Aggregate> EventStore<A> for MemStore<A> {
     type AC = MemStoreAggregateContext<A>;
 

--- a/src/persist/doc.rs
+++ b/src/persist/doc.rs
@@ -66,7 +66,6 @@ impl MyEventRepository {
     }
 }
 
-#[async_trait]
 impl PersistedEventRepository for MyEventRepository {
     async fn get_events<A: Aggregate>(
         &self,

--- a/src/persist/doc.rs
+++ b/src/persist/doc.rs
@@ -5,7 +5,6 @@ use crate::persist::{
     ViewRepository,
 };
 use crate::{Aggregate, EventEnvelope, View};
-use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
@@ -27,7 +26,6 @@ impl MyViewRepository {
     }
 }
 
-#[async_trait]
 impl ViewRepository<MyView, MyAggregate> for MyViewRepository {
     async fn load(&self, _view_id: &str) -> Result<Option<MyView>, PersistenceError> {
         todo!()

--- a/src/persist/event_repository.rs
+++ b/src/persist/event_repository.rs
@@ -1,44 +1,46 @@
+use std::future::Future;
+
 use crate::persist::event_stream::ReplayStream;
 use crate::persist::{PersistenceError, SerializedEvent, SerializedSnapshot};
 use crate::Aggregate;
-use async_trait::async_trait;
 use serde_json::Value;
 
 /// Handles the database access needed for operation of a PersistedSnapshotStore.
-#[async_trait]
 pub trait PersistedEventRepository: Send + Sync {
     /// Returns all events for a single aggregate instance.
-    async fn get_events<A: Aggregate>(
+    fn get_events<A: Aggregate>(
         &self,
         aggregate_id: &str,
-    ) -> Result<Vec<SerializedEvent>, PersistenceError>;
+    ) -> impl Future<Output = Result<Vec<SerializedEvent>, PersistenceError>> + Send;
 
     /// Returns the last events for a single aggregate instance.
-    async fn get_last_events<A: Aggregate>(
+    fn get_last_events<A: Aggregate>(
         &self,
         aggregate_id: &str,
         last_sequence: usize,
-    ) -> Result<Vec<SerializedEvent>, PersistenceError>;
+    ) -> impl Future<Output = Result<Vec<SerializedEvent>, PersistenceError>> + Send;
 
     /// Returns the current snapshot for an aggregate instance.
-    async fn get_snapshot<A: Aggregate>(
+    fn get_snapshot<A: Aggregate>(
         &self,
         aggregate_id: &str,
-    ) -> Result<Option<SerializedSnapshot>, PersistenceError>;
+    ) -> impl Future<Output = Result<Option<SerializedSnapshot>, PersistenceError>> + Send;
 
     /// Commits the updated aggregate and accompanying events.
-    async fn persist<A: Aggregate>(
+    fn persist<A: Aggregate>(
         &self,
         events: &[SerializedEvent],
         snapshot_update: Option<(String, Value, usize)>,
-    ) -> Result<(), PersistenceError>;
+    ) -> impl Future<Output = Result<(), PersistenceError>> + Send;
 
     /// Streams all events for an aggregate instance.
-    async fn stream_events<A: Aggregate>(
+    fn stream_events<A: Aggregate>(
         &self,
         aggregate_id: &str,
-    ) -> Result<ReplayStream, PersistenceError>;
+    ) -> impl Future<Output = Result<ReplayStream, PersistenceError>> + Send;
 
     /// Streams all events for an aggregate type.
-    async fn stream_all_events<A: Aggregate>(&self) -> Result<ReplayStream, PersistenceError>;
+    fn stream_all_events<A: Aggregate>(
+        &self,
+    ) -> impl Future<Output = Result<ReplayStream, PersistenceError>> + Send;
 }

--- a/src/persist/event_store.rs
+++ b/src/persist/event_store.rs
@@ -307,7 +307,6 @@ where
 #[cfg(test)]
 pub(crate) mod shared_test {
     use std::collections::HashMap;
-    use std::future::Future;
     use std::sync::Mutex;
 
     use serde::{Deserialize, Serialize};
@@ -368,15 +367,15 @@ pub(crate) mod shared_test {
         type Error = TestError;
         type Services = TestService;
 
-        fn handle(
+        async fn handle(
             &self,
             command: Self::Command,
             _service: &Self::Services,
-        ) -> impl Future<Output = Result<Vec<Self::Event>, Self::Error>> + Send {
-            std::future::ready(match command {
+        ) -> Result<Vec<Self::Event>, Self::Error> {
+            match command {
                 TestCommands::DoSomething => Ok(vec![TestEvents::SomethingWasDone]),
                 TestCommands::BadCommand => Err("the expected error message".into()),
-            })
+            }
         }
         fn apply(&mut self, event: Self::Event) {
             match event {

--- a/src/persist/event_store.rs
+++ b/src/persist/event_store.rs
@@ -1,7 +1,6 @@
 use std::collections::HashMap;
 use std::marker::PhantomData;
 
-use async_trait::async_trait;
 use serde_json::Value;
 
 use crate::persist::serialized_event::{deserialize_events, serialize_events};
@@ -176,7 +175,6 @@ where
     }
 }
 
-#[async_trait]
 impl<R, A> EventStore<A> for PersistedEventStore<R, A>
 where
     R: PersistedEventRepository,
@@ -312,7 +310,6 @@ pub(crate) mod shared_test {
     use std::future::Future;
     use std::sync::Mutex;
 
-    use async_trait::async_trait;
     use serde::{Deserialize, Serialize};
     use serde_json::Value;
 
@@ -364,7 +361,6 @@ pub(crate) mod shared_test {
         pub(crate) something_happened: usize,
     }
 
-    #[async_trait]
     impl Aggregate for TestAggregate {
         const TYPE: &'static str = "TestAggregate";
         type Command = TestCommands;

--- a/src/persist/event_store.rs
+++ b/src/persist/event_store.rs
@@ -309,6 +309,7 @@ where
 #[cfg(test)]
 pub(crate) mod shared_test {
     use std::collections::HashMap;
+    use std::future::Future;
     use std::sync::Mutex;
 
     use async_trait::async_trait;
@@ -371,15 +372,15 @@ pub(crate) mod shared_test {
         type Error = TestError;
         type Services = TestService;
 
-        async fn handle(
+        fn handle(
             &self,
             command: Self::Command,
             _service: &Self::Services,
-        ) -> Result<Vec<Self::Event>, Self::Error> {
-            match command {
+        ) -> impl Future<Output = Result<Vec<Self::Event>, Self::Error>> + Send {
+            std::future::ready(match command {
                 TestCommands::DoSomething => Ok(vec![TestEvents::SomethingWasDone]),
                 TestCommands::BadCommand => Err("the expected error message".into()),
-            }
+            })
         }
         fn apply(&mut self, event: Self::Event) {
             match event {

--- a/src/persist/event_store.rs
+++ b/src/persist/event_store.rs
@@ -447,7 +447,6 @@ pub(crate) mod shared_test {
         }
     }
 
-    #[async_trait]
     impl PersistedEventRepository for MockRepo {
         async fn get_events<A: Aggregate>(
             &self,

--- a/src/persist/view_repository.rs
+++ b/src/persist/view_repository.rs
@@ -1,27 +1,34 @@
+use std::future::Future;
+
 use crate::persist::PersistenceError;
 use crate::{Aggregate, View};
-use async_trait::async_trait;
 
 /// Handles the database access needed for a GenericQuery.
-#[async_trait]
 pub trait ViewRepository<V, A>: Send + Sync
 where
     V: View<A>,
     A: Aggregate,
 {
     /// Returns the current view instance.
-    async fn load(&self, view_id: &str) -> Result<Option<V>, PersistenceError>;
+    fn load(
+        &self,
+        view_id: &str,
+    ) -> impl Future<Output = Result<Option<V>, PersistenceError>> + Send;
 
     /// Returns the current view instance and context, used by the `GenericQuery` to update
     /// views with committed events.
-    async fn load_with_context(
+    fn load_with_context(
         &self,
         view_id: &str,
-    ) -> Result<Option<(V, ViewContext)>, PersistenceError>;
+    ) -> impl Future<Output = Result<Option<(V, ViewContext)>, PersistenceError>> + Send;
 
     /// Updates the view instance and context, used by the `GenericQuery` to update
     /// views with committed events.
-    async fn update_view(&self, view: V, context: ViewContext) -> Result<(), PersistenceError>;
+    fn update_view(
+        &self,
+        view: V,
+        context: ViewContext,
+    ) -> impl Future<Output = Result<(), PersistenceError>> + Send;
 }
 
 /// A data structure maintaining context when updating views.

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -28,7 +28,6 @@ impl From<&str> for TestError {
 #[derive(Clone, Debug)]
 pub struct TestService;
 
-#[async_trait]
 impl Aggregate for TestAggregate {
     const TYPE: &'static str = "TestAggregate";
     type Command = TestCommand;


### PR DESCRIPTION
remove unneeded uses of async-trait.

I've left it in place for a couple of use-cases where it makes sense. For example the 'Query' trait is stored as a dyn trait object so the futures it returns have to be boxed. Without the 'async-trait' macro you'd have to basically hand-roll the exact code it would write anyway