### PR TITLE
Allow TestFramework to use Store and Queries

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,3 +45,4 @@ tokio = { workspace = true, features = ["macros", "sync", "rt"] }
 [dev-dependencies]
 uuid.workspace = true
 chrono = { version = "^0.4.41", default-features = false, features = ["clock"] }
+tokio = { workspace = true, features = ["macros", "sync", "rt-multi-thread"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,9 +40,8 @@ async-trait = "0.1"
 serde = { workspace = true, features = ["derive"] }
 serde_json = "1.0"
 thiserror = "^2.0.12"
-tokio = { workspace = true, features = ["macros", "sync", "rt"] }
+tokio = { workspace = true, features = ["macros", "sync", "rt-multi-thread"] }
 
 [dev-dependencies]
 uuid.workspace = true
 chrono = { version = "^0.4.41", default-features = false, features = ["clock"] }
-tokio = { workspace = true, features = ["macros", "sync", "rt-multi-thread"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ async-trait = "0.1"
 serde = { workspace = true, features = ["derive"] }
 serde_json = "1.0"
 thiserror = "^2.0.12"
-tokio = { workspace = true, features = ["macros", "sync", "rt-multi-thread"] }
+tokio = { workspace = true, features = ["macros", "sync", "rt"] }
 
 [dev-dependencies]
 uuid.workspace = true

--- a/src/mem_store.rs
+++ b/src/mem_store.rs
@@ -4,7 +4,7 @@ use std::sync::{Arc, RwLock};
 use crate::event::EventEnvelope;
 use crate::{Aggregate, AggregateContext, AggregateError, EventStore};
 
-///  Simple memory store useful for application development and testing purposes.
+/// Simple memory store useful for application development and testing purposes.
 ///
 /// Creation and use in a constructing a `CqrsFramework`:
 /// ```

--- a/src/mem_store.rs
+++ b/src/mem_store.rs
@@ -181,6 +181,19 @@ where
     pub current_sequence: usize,
 }
 
+impl<A> Default for MemStoreAggregateContext<A>
+where
+    A: Aggregate + Default,
+{
+    fn default() -> Self {
+        Self {
+            aggregate_id: String::from(""),
+            aggregate: A::default(),
+            current_sequence: 0,
+        }
+    }
+}
+
 impl<A> AggregateContext<A> for MemStoreAggregateContext<A>
 where
     A: Aggregate,

--- a/src/test/executor.rs
+++ b/src/test/executor.rs
@@ -135,16 +135,15 @@ where
     AC: AggregateContext<A>,
     S: EventStore<A, AC = AC>,
 {
-    use tokio::runtime::Runtime;
-
     if let Some((ctx, store)) = context_store {
-        let rt = Runtime::new().expect("Failed to create Tokio runtime");
         let events = events.clone();
-        rt.block_on(async {
-            store
-                .commit(events.clone(), ctx, std::collections::HashMap::default())
-                .await
-                .expect("Failed to persist events in AggregateTestExecutor");
-        })
+        tokio::task::block_in_place(|| {
+            tokio::runtime::Handle::current().block_on(async {
+                store
+                    .commit(events.clone(), ctx, std::collections::HashMap::default())
+                    .await
+                    .expect("persist events in AggregateTestExecutor should be successful");
+            })
+        });
     }
 }

--- a/src/test/framework.rs
+++ b/src/test/framework.rs
@@ -1,23 +1,90 @@
 use crate::aggregate::Aggregate;
+use crate::mem_store::MemStore;
+use crate::mem_store::MemStoreAggregateContext;
+use crate::query::Query;
+use crate::store::{AggregateContext, EventStore};
 use crate::test::AggregateTestExecutor;
 
 /// A framework for rigorously testing the aggregate logic, one of the *most important*
 /// parts of any DDD system.
-pub struct TestFramework<A: Aggregate> {
+pub type TestFramework<A> = GenericTestFramework<A, MemStoreAggregateContext<A>, MemStore<A>>;
+
+/// The framework implementation.
+pub struct GenericTestFramework<A, AC, S>
+where
+    A: Aggregate,
+    AC: AggregateContext<A>,
+    S: EventStore<A, AC = AC>,
+{
     service: A::Services,
+    queries: Vec<Box<dyn Query<A>>>,
+    context_store: Option<(AC, S)>,
 }
 
-impl<A: Aggregate> TestFramework<A> {
-    /// Create a test framework using the provided service.
+impl<A: Aggregate> GenericTestFramework<A, MemStoreAggregateContext<A>, MemStore<A>> {
+    /// Create a test framework using the provided service. No queries or event store are defined.
     pub fn with(service: A::Services) -> Self {
-        Self { service }
+        let queries = Vec::default();
+        let context_store = None;
+        Self {
+            service,
+            queries,
+            context_store,
+        }
+    }
+
+    /// Use an event store within the current test framework.
+    pub fn using_context_and_store<SO, ACO>(
+        self,
+        context: ACO,
+        store: SO,
+    ) -> GenericTestFramework<A, ACO, SO>
+    where
+        ACO: AggregateContext<A>,
+        SO: EventStore<A, AC = ACO>,
+    {
+        let service = self.service;
+        let queries = self.queries;
+        let context_store = Some((context, store));
+        GenericTestFramework {
+            service,
+            queries,
+            context_store,
+        }
+    }
+
+    /// Use a [MemStore] event store within the current test framework.
+    pub fn using_mem_store<SO, ACO>(self) -> Self {
+        self.using_context_and_store(MemStoreAggregateContext::default(), MemStore::default())
     }
 }
 
-impl<A> TestFramework<A>
+impl<A, AC, S> GenericTestFramework<A, AC, S>
 where
     A: Aggregate,
+    AC: AggregateContext<A>,
+    S: EventStore<A, AC = AC>,
 {
+    /// Add a query into the current test framework. An event store must be defined
+    /// before providing pre-conditions with ([given_no_previous_events] / [given]).
+    pub fn and_query(self, query: Box<dyn Query<A>>) -> Self {
+        let service = self.service;
+        let mut queries = self.queries;
+        queries.push(query);
+        let context_store = self.context_store;
+        Self {
+            service,
+            queries,
+            context_store,
+        }
+    }
+
+    /// Add all queries into the current test framework. An event store must be defined
+    /// before providing pre-conditions ([given_no_previous_events] / [given]).
+    pub fn and_queries(self, queries: Vec<Box<dyn Query<A>>>) -> Self {
+        queries.into_iter().fold(self, |acc, q| acc.and_query(q))
+    }
+
     /// Initiates an aggregate test with no previous events.
     ///
     /// ```
@@ -28,8 +95,8 @@ where
     ///     .given_no_previous_events();
     /// ```
     #[must_use]
-    pub fn given_no_previous_events(self) -> AggregateTestExecutor<A> {
-        AggregateTestExecutor::new(Vec::new(), self.service)
+    pub fn given_no_previous_events(self) -> AggregateTestExecutor<A, AC, S> {
+        AggregateTestExecutor::new(Vec::new(), self.service, self.queries, self.context_store)
     }
     /// Initiates an aggregate test with a collection of previous events.
     ///
@@ -41,7 +108,7 @@ where
     ///     .given(vec![MyEvents::SomethingWasDone]);
     /// ```
     #[must_use]
-    pub fn given(self, events: Vec<A::Event>) -> AggregateTestExecutor<A> {
-        AggregateTestExecutor::new(events, self.service)
+    pub fn given(self, events: Vec<A::Event>) -> AggregateTestExecutor<A, AC, S> {
+        AggregateTestExecutor::new(events, self.service, self.queries, self.context_store)
     }
 }

--- a/src/test/framework.rs
+++ b/src/test/framework.rs
@@ -54,7 +54,9 @@ impl<A: Aggregate> GenericTestFramework<A, MemStoreAggregateContext<A>, MemStore
     }
 
     /// Use a [MemStore] event store within the current test framework.
-    pub fn using_mem_store<SO, ACO>(self) -> Self {
+    pub fn using_mem_store(
+        self,
+    ) -> GenericTestFramework<A, MemStoreAggregateContext<A>, MemStore<A>> {
         self.using_context_and_store(MemStoreAggregateContext::default(), MemStore::default())
     }
 }

--- a/src/test/framework.rs
+++ b/src/test/framework.rs
@@ -6,7 +6,9 @@ use crate::store::{AggregateContext, EventStore};
 use crate::test::AggregateTestExecutor;
 
 /// A framework for rigorously testing the aggregate logic, one of the *most important*
-/// parts of any DDD system.
+/// parts of any DDD system. Note: the defaulted [AggregateContext] and [Store] types
+/// are incidental as the default `context_store` is None. The types are defined when
+/// using [`using_context_and_store`] and [`using_mem_store`].
 pub type TestFramework<A> = GenericTestFramework<A, MemStoreAggregateContext<A>, MemStore<A>>;
 
 /// The framework implementation.


### PR DESCRIPTION
This PR enables the TestFramework to include a Store and defined Query(s) to be executed. By default there is no impact on existing users as the "default store" is None, with no queries.  A test (and "example") is added in the tests/lib.rs.

The original TestFramework type is renamed GenericTestFramework, which includes typing for AggregateContext and Store.  To keep compatibility, a TestFramework type is defined with default _types_ for the GenericTestFramework.

This is a precursor to introducing Reactors & enabling sagas.

If this doesn't fit in with the design constraints, or there's already an easier way to achieve the above, please let us know.

Happy to discuss / amend to bring it up to internal standards. 