### PR TITLE
build: disable default features for `sqlx`

### DIFF
--- a/persistence/mysql-es/Cargo.toml
+++ b/persistence/mysql-es/Cargo.toml
@@ -13,9 +13,9 @@ readme = "README.md"
 [dependencies]
 cqrs-es.workspace = true
 futures = "0.3"
-serde = { workspace = true, features = ["derive"]}
+serde = { workspace = true, features = ["derive"] }
 serde_json = "1.0"
-sqlx = { version = "0.8", features = [ "mysql", "json"] }
+sqlx = { version = "0.8", default-features = false, features = ["mysql", "json"] }
 tokio = { workspace = true, features = ["rt"] }
 thiserror = "2.0.12"
 

--- a/persistence/postgres-es/Cargo.toml
+++ b/persistence/postgres-es/Cargo.toml
@@ -15,7 +15,7 @@ cqrs-es.workspace = true
 futures = "0.3"
 serde = { workspace = true, features = ["derive"] }
 serde_json = "1.0"
-sqlx = { version = "0.8", features = ["postgres", "json"] }
+sqlx = { version = "0.8", default-features = false, features = ["postgres", "json"] }
 tokio = { workspace = true, features = ["rt"] }
 thiserror = "2.0.12"
 


### PR DESCRIPTION
The `sqlx` crate enables the `any` feature by default which includes `sqlx-mysql`, `sqlx-postgres` and `sqlx-sqlite`.

Currently, `postgres-es` and `mysql-es` do not disable default features for `sqlx`, so they both pull in all `sqlx-*`.
I believe this was not the intention since `postgres` and `mysql` features are explicitly enabled.

This change disables default features for `sqlx` to keep only postgres-related features in `postgres-es` and same for `mysql-es`.