### PR TITLE
Validator change for matching events

### DIFF
--- a/src/doc.rs
+++ b/src/doc.rs
@@ -264,7 +264,7 @@ mod doc_tests {
     }
 
     #[test]
-    fn test_add_email_name_populted() {
+    fn test_add_email_name_populated() {
         CustomerTestFramework::with(CustomerService)
             .given(vec![CustomerEvent::NameAdded {
                 name: "John Doe".to_string(),
@@ -278,5 +278,43 @@ mod doc_tests {
                 },
                 CustomerEvent::CustomerDataPopulated,
             ]);
+    }
+
+    #[test]
+    fn test_add_email_name_populated_single_event() {
+        CustomerTestFramework::with(CustomerService)
+            .given(vec![CustomerEvent::NameAdded {
+                name: "John Doe".to_string(),
+            }])
+            .when(CustomerCommand::UpdateEmail {
+                new_email: "john.doe@example.com".to_string(),
+            })
+            .then_expect_events_matching(vec![CustomerEvent::EmailUpdated {
+                new_email: "john.doe@example.com".to_string(),
+            }]);
+
+        CustomerTestFramework::with(CustomerService)
+            .given(vec![CustomerEvent::NameAdded {
+                name: "John Doe".to_string(),
+            }])
+            .when(CustomerCommand::UpdateEmail {
+                new_email: "john.doe@example.com".to_string(),
+            })
+            .then_expect_events_matching(vec![CustomerEvent::CustomerDataPopulated]);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_add_email_name_populated_single_event_missing() {
+        CustomerTestFramework::with(CustomerService)
+            .given(vec![CustomerEvent::NameAdded {
+                name: "John Doe".to_string(),
+            }])
+            .when(CustomerCommand::UpdateEmail {
+                new_email: "john.doe@example.com".to_string(),
+            })
+            .then_expect_events_matching(vec![CustomerEvent::EmailUpdated {
+                new_email: "incorrect_email@example.com".to_string(),
+            }]);
     }
 }

--- a/src/test/validator.rs
+++ b/src/test/validator.rs
@@ -30,6 +30,46 @@ impl<A: Aggregate> AggregateResultValidator<A> {
         assert_eq!(events, expected_events);
     }
 
+    /// Verifies that the individual expected events have been produced by the command.
+    /// This only checks that the events exist, it does not verify the order nor does it check any
+    /// events that are not provided.
+    ///
+    /// ```
+    /// # use cqrs_es::doc::{MyAggregate, MyCommands, MyEvents, MyService};
+    /// # async fn test() {
+    /// use cqrs_es::test::TestFramework;
+    ///
+    /// let validator = TestFramework::<MyAggregate>::with(MyService)
+    ///     .given_no_previous_events()
+    ///     .when(MyCommands::DoSomething);
+    ///
+    /// validator.then_expect_events_matching(vec![MyEvents::SomethingWasDone]);
+    /// # }
+    /// ```
+    pub fn then_expect_events_matching(self, expected_events: Vec<A::Event>) {
+        let events = self.result.unwrap_or_else(|err| {
+            panic!("expected success, received aggregate error: '{err}'");
+        });
+        let mut missing_events: Vec<A::Event> = Default::default();
+        for expected_event in expected_events {
+            if !Self::event_exists(&expected_event, &events) {
+                missing_events.push(expected_event);
+            }
+        }
+        if !missing_events.is_empty() {
+            panic!("missing events: '{missing_events:?}'\n  found: '{events:?}");
+        }
+    }
+
+    fn event_exists(expected_event: &A::Event, actual_events: &[A::Event]) -> bool {
+        for event in actual_events {
+            if expected_event == event {
+                return true;
+            }
+        }
+        false
+    }
+
     /// Verifies that the result is a `UserError` and returns the internal error payload for
     /// further validation.
     ///


### PR DESCRIPTION
An additional method was added to the test framework validator for checking events regardless of the order (and ignoring non-specified) events.